### PR TITLE
Remove invalid CIRCLE init args from MAKE-CIRCLE

### DIFF
--- a/src/circle.lisp
+++ b/src/circle.lisp
@@ -11,7 +11,6 @@
 
 (defun make-circle (x y radius color &key (filled t))
   (make-instance 'circle
-                 :x x :y y
                  :pos (make-vector2 x y)
                  :radius radius
                  :color color


### PR DESCRIPTION
:POS used with the X/Y accessors (defined by DEFREADER/DEFWRITER on 2D-OBJECT)
already do the job