### PR TITLE
Add some examples, including gradient capability for circles/rectangles

### DIFF
--- a/claylib.asd
+++ b/claylib.asd
@@ -101,4 +101,5 @@
                    (:file "28-custom-frame-control")))
                  (:module "shapes"
                   :components
-                  ((:file "02-bouncing-ball")))))))
+                  ((:file "02-bouncing-ball")
+                   (:file "03-colors-palette")))))))

--- a/claylib.asd
+++ b/claylib.asd
@@ -101,5 +101,6 @@
                    (:file "28-custom-frame-control")))
                  (:module "shapes"
                   :components
-                  ((:file "02-bouncing-ball")
+                  ((:file "01-basic-shapes")
+                   (:file "02-bouncing-ball")
                    (:file "03-colors-palette")))))))

--- a/claylib.asd
+++ b/claylib.asd
@@ -98,4 +98,7 @@
                    (:file "25-window-flags")
                    (:file "26-split-screen")
                    (:file "27-smooth-pixelperfect")
-                   (:file "28-custom-frame-control")))))))
+                   (:file "28-custom-frame-control")))
+                 (:module "shapes"
+                  :components
+                  ((:file "02-bouncing-ball")))))))

--- a/claylib.asd
+++ b/claylib.asd
@@ -97,4 +97,5 @@
                    (:file "24-quat-conversion")
                    (:file "25-window-flags")
                    (:file "26-split-screen")
-                   (:file "27-smooth-pixelperfect")))))))
+                   (:file "27-smooth-pixelperfect")
+                   (:file "28-custom-frame-control")))))))

--- a/examples/core/28-custom-frame-control.lisp
+++ b/examples/core/28-custom-frame-control.lisp
@@ -1,0 +1,116 @@
+(in-package #:claylib/examples)
+
+(defun example-core-28 ()
+  (with-window (:title "raylib [core] example - custom frame control")
+    (let ((scene
+            (make-scene ()
+                        `(,@(loop for i = 0 then (1+ i)
+                                  for name = (intern (concatenate
+                                                      'string
+                                                      "line-"
+                                                      (write-to-string i)))
+                                  until (> i (/ (get-screen-width) 200))
+                                  collect `(,name ,(make-rectangle (* 200 i)
+                                                    0
+                                                    1
+                                                    (get-screen-height)
+                                                    +skyblue+)))
+                          (ball ,(make-circle 0
+                                              (- (/ (get-screen-height) 2) 25)
+                                              50
+                                              +red+))
+                          (text-timer ,(make-text "0"
+                                                  30
+                                                  (- (/ (get-screen-height) 2) 100)
+                                                  :size 20
+                                                  :color +maroon+))
+                          (text-pos-x ,(make-text "10"
+                                                  -40
+                                                  (+ (/ (get-screen-height) 2) 40)
+                                                  :size 20
+                                                  :color +black+))
+                          (text-info ,(make-text "Circle is moving at a constant 200 pixels/sec,
+independently of the frame rate."
+                                                 10
+                                                 10
+                                                 :size 20
+                                                 :color +darkgray+))
+                          (text-space ,(make-text "PRESS SPACE to PAUSE MOVEMENT"
+                                                  10
+                                                  (- (get-screen-height) 60)
+                                                  :size 20
+                                                  :color +gray+))
+                          (text-change-fps ,(make-text "PRESS UP | DOWN to CHANGE TARGET FPS"
+                                                       10
+                                                       (- (get-screen-height) 30)
+                                                       :size 20
+                                                       :color +gray+))
+                          (text-target-fps ,(make-text "TARGET FPS:"
+                                                       (- (get-screen-width) 220)
+                                                       10
+                                                       :size 20
+                                                       :color +lime+))
+                          (text-current-fps ,(make-text "CURRENT FPS:"
+                                                        (- (get-screen-width) 220)
+                                                        40
+                                                        :size 20
+                                                        :color +green+))))))
+      (with-scene scene ()
+        (do-game-loop (:livesupport t
+                       :vars ((previous-time (get-time))
+                              (current-time 0.0)
+                              (update-draw-time 0.0)
+                              (wait-time 0.0)
+                              (delta-time 0.0)
+                              (time-counter 0.0)
+                              (pause nil)
+                              (target-fps 60)))
+          ;; Update
+          ;; ---------------------------------
+          (when (is-key-pressed-p +key-space+)
+            (setf pause (not pause)))
+
+          (if (is-key-pressed-p +key-up+)
+              (incf target-fps 20)
+              (when (is-key-pressed-p +key-down+)
+                (decf target-fps 20)))
+          (when (< target-fps 0)
+            (setf target-fps 0))
+
+          (unless pause
+            (with-scene-objects (ball text-timer text-pos-x text-target-fps text-current-fps) scene
+              (when (>= (incf (x ball) (coerce (* 200 delta-time) 'single-float))
+                        (get-screen-width))
+                (setf (x ball) 0))
+              (setf (text text-timer) (format nil "~,0f ms" (* time-counter 1000))
+                    (x text-timer) (- (x ball) 40)
+                    (y text-timer) (- (/ (get-screen-height) 2) 100)
+                    (text text-pos-x) (format nil "PosX: ~,0f" (x ball))
+                    (x text-pos-x) (- (x ball) 50)
+                    (y text-pos-x) (+ (/ (get-screen-height) 2) 40)
+                    (text text-target-fps) (format nil "TARGET FPS: ~d" target-fps)
+                    (text text-current-fps) (format nil
+                                                    "CURRENT FPS: ~d"
+                                                    (if (= delta-time 0)
+                                                        0
+                                                        (floor (/ 1 delta-time)))))
+              (incf time-counter delta-time)))
+
+          ;; Draw
+          ;; ---------------------------------
+          (with-drawing
+            (draw-scene-all scene))
+
+          (claylib/wrap:swap-screen-buffer)
+
+          (setf current-time (get-time))
+          (setf update-draw-time (- current-time previous-time))
+
+          (if (> target-fps 0)
+              (when (> (setf wait-time (- (/ 1.0 target-fps) update-draw-time)) 0)
+                (claylib/wrap:wait-time (coerce (* wait-time 1000) 'single-float))
+                (setf current-time (get-time))
+                (setf delta-time (- current-time previous-time)))
+              (setf delta-time update-draw-time))
+
+          (setf previous-time current-time))))))

--- a/examples/core/28-custom-frame-control.lisp
+++ b/examples/core/28-custom-frame-control.lisp
@@ -98,14 +98,14 @@ independently of the frame rate."
           (with-drawing
             (draw-scene-all scene))
 
-          (claylib/wrap:swap-screen-buffer)
+          (claylib/ll:swap-screen-buffer)
 
           (setf current-time (get-time))
           (setf update-draw-time (- current-time previous-time))
 
           (if (> target-fps 0)
               (when (> (setf wait-time (- (/ 1.0 target-fps) update-draw-time)) 0)
-                (claylib/wrap:wait-time (coerce (* wait-time 1000) 'single-float))
+                (claylib/ll:wait-time (coerce (* wait-time 1000) 'single-float))
                 (setf current-time (get-time))
                 (setf delta-time (- current-time previous-time)))
               (setf delta-time update-draw-time)))))))

--- a/examples/core/28-custom-frame-control.lisp
+++ b/examples/core/28-custom-frame-control.lisp
@@ -57,7 +57,7 @@ independently of the frame rate."
                                                         :color +green+))))))
       (with-scene scene ()
         (do-game-loop (:livesupport t
-                       :vars ((previous-time (get-time))
+                       :vars ((previous-time (get-time) current-time)
                               (current-time 0.0)
                               (update-draw-time 0.0)
                               (wait-time 0.0)
@@ -111,6 +111,4 @@ independently of the frame rate."
                 (claylib/wrap:wait-time (coerce (* wait-time 1000) 'single-float))
                 (setf current-time (get-time))
                 (setf delta-time (- current-time previous-time)))
-              (setf delta-time update-draw-time))
-
-          (setf previous-time current-time))))))
+              (setf delta-time update-draw-time)))))))

--- a/examples/core/28-custom-frame-control.lisp
+++ b/examples/core/28-custom-frame-control.lisp
@@ -5,10 +5,7 @@
     (let ((scene
             (make-scene ()
                         `(,@(loop for i = 0 then (1+ i)
-                                  for name = (intern (concatenate
-                                                      'string
-                                                      "line-"
-                                                      (write-to-string i)))
+                                  for name = (gensym "LINE")
                                   until (> i (/ (get-screen-width) 200))
                                   collect `(,name ,(make-rectangle (* 200 i)
                                                     0

--- a/examples/shapes/01-basic-shapes.lisp
+++ b/examples/shapes/01-basic-shapes.lisp
@@ -1,0 +1,46 @@
+(in-package #:claylib/examples)
+
+(defun example-shapes-01 ()
+  (with-window (:title "raylib [shapes] example - Draw basic shapes 2d (rectangle, circle, line...)")
+    (let ((scene (make-scene ()
+                             `((text-title ,(make-text "some basic shapes available on raylib"
+                                                       20
+                                                       20
+                                                       :size 20
+                                                       :color +darkgray+))
+                               (circle ,(make-circle (/ (get-screen-width) 5)
+                                                     120
+                                                     35
+                                                     +darkblue+))
+                               (circle-gradient ,(make-circle (/ (get-screen-width) 5)
+                                                              220
+                                                              60
+                                                              +green+
+                                                              :color2 +skyblue+))
+                               (circle-lines ,(make-circle (/ (get-screen-width) 5)
+                                                           340
+                                                           80
+                                                           +darkblue+
+                                                           :filled nil))
+                               (rect ,(make-rectangle (- (/ (get-screen-width) 2) 60)
+                                                      100
+                                                      120
+                                                      60
+                                                      +red+))
+                               (rect-gradient ,(make-rectangle (- (/ (get-screen-width) 2) 90)
+                                                               170
+                                                               180
+                                                               130
+                                                               +maroon+
+                                                               :color2 +gold+
+                                                               :gradient-style :h))
+                               (rect-lines ,(make-rectangle (- (/ (get-screen-width) 2) 40)
+                                                            320
+                                                            80
+                                                            60
+                                                            +orange+
+                                                            :filled nil))))))
+      (with-scene scene ()
+        (do-game-loop (:livesupport t)
+          (with-drawing
+            (draw-scene-all scene)))))))

--- a/examples/shapes/02-bouncing-ball.lisp
+++ b/examples/shapes/02-bouncing-ball.lisp
@@ -1,0 +1,69 @@
+(in-package #:claylib/examples)
+
+(defclass ball (circle)
+  ((%speed :initarg :speed
+           :type rl-vector2
+           :reader speed)))
+
+(defun make-ball (x y radius color vx vy &key (filled t))
+  "Make an BALL instance where VX and XY are the x and y components of the BALL's SPEED."
+  (make-instance 'ball
+                 :pos (make-vector2 x y)
+                 :radius radius
+                 :color color
+                 :speed (make-vector2 vx vy)
+                 :filled filled))
+
+(defun move-ball (ball)
+  "Update BALL position based on its speed."
+  (incf (x ball) (x (speed ball)))
+  (incf (y ball) (y (speed ball))))
+
+(defun bounce-ball (ball screen-width screen-height)
+  "Negate the speed of the given BALL to make it bounce off the edges of the screen."
+  (let ((x (x ball))
+        (y (y ball))
+        (radius (radius ball)))
+    (when (or (>= x (- screen-width radius)) (<= x radius))
+      (setf (x (speed ball)) (- (x (speed ball)))))
+    (when (or (>= y (- screen-height radius)) (<= y radius))
+      (setf (y (speed ball)) (- (y (speed ball)))))))
+
+(defun example-shapes-02 ()
+  (with-window (:title "raylib [shapes] example - bouncing ball")
+    (let ((scene (make-scene ()
+                             `((ball ,(make-ball (/ (get-screen-width) 2.0)
+                                                 (/ (get-screen-height) 2.0)
+                                                 20
+                                                 +maroon+
+                                                 5
+                                                 4))
+                               (text ,(make-text "PRESS SPACE to PAUSE BALL MOVEMENT"
+                                                 10
+                                                 (- (get-screen-height) 25)
+                                                 :size 20
+                                                 :color +lightgray+))
+                               (text-pause ,(make-text "PAUSED"
+                                                       350
+                                                       200
+                                                       :size 30
+                                                       :color +gray+))))))
+      (with-scene scene ()
+        (do-game-loop (:livesupport t
+                       :vars ((pause nil)
+                              (frames-counter 0)))
+          (when (is-key-pressed-p +key-space+)
+            (setf pause (not pause)))
+
+          (with-scene-objects (ball) scene
+            (if (not pause)
+                (progn
+                  (move-ball ball)
+                  (bounce-ball ball (get-screen-width) (get-screen-height)))
+                (incf frames-counter)))
+
+          (with-drawing
+            (if (and pause (= 0 (mod (floor frames-counter 30) 2)))
+                (draw-scene-all scene)
+                (draw-scene-except scene 'text-pause))
+            (draw-fps 10 10)))))))

--- a/examples/shapes/02-bouncing-ball.lisp
+++ b/examples/shapes/02-bouncing-ball.lisp
@@ -63,7 +63,7 @@
                 (incf frames-counter)))
 
           (with-drawing
-            (if (and pause (= 0 (mod (floor frames-counter 30) 2)))
+            (if (and pause (= 0 (mod (truncate frames-counter 30) 2)))
                 (draw-scene-all scene)
                 (draw-scene-except scene 'text-pause))
             (draw-fps 10 10)))))))

--- a/examples/shapes/02-bouncing-ball.lisp
+++ b/examples/shapes/02-bouncing-ball.lisp
@@ -1,33 +1,33 @@
 (in-package #:claylib/examples)
 
 (defclass ball (circle)
-  ((%speed :initarg :speed
+  ((%velocity :initarg :velocity
            :type rl-vector2
-           :reader speed)))
+           :reader velocity)))
 
 (defun make-ball (x y radius color vx vy &key (filled t))
-  "Make an BALL instance where VX and XY are the x and y components of the BALL's SPEED."
+  "Make an BALL instance where VX and XY are the x and y components of the BALL's VELOCITY."
   (make-instance 'ball
                  :pos (make-vector2 x y)
                  :radius radius
                  :color color
-                 :speed (make-vector2 vx vy)
+                 :velocity (make-vector2 vx vy)
                  :filled filled))
 
 (defun move-ball (ball)
-  "Update BALL position based on its speed."
-  (incf (x ball) (x (speed ball)))
-  (incf (y ball) (y (speed ball))))
+  "Update BALL position based on its velocity."
+  (incf (x ball) (x (velocity ball)))
+  (incf (y ball) (y (velocity ball))))
 
 (defun bounce-ball (ball screen-width screen-height)
-  "Negate the speed of the given BALL to make it bounce off the edges of the screen."
+  "Negate the velocity of the given BALL to make it bounce off the edges of the screen."
   (let ((x (x ball))
         (y (y ball))
         (radius (radius ball)))
     (when (or (>= x (- screen-width radius)) (<= x radius))
-      (setf (x (speed ball)) (- (x (speed ball)))))
+      (setf (x (velocity ball)) (- (x (velocity ball)))))
     (when (or (>= y (- screen-height radius)) (<= y radius))
-      (setf (y (speed ball)) (- (y (speed ball)))))))
+      (setf (y (velocity ball)) (- (y (velocity ball)))))))
 
 (defun example-shapes-02 ()
   (with-window (:title "raylib [shapes] example - bouncing ball")

--- a/examples/shapes/02-bouncing-ball.lisp
+++ b/examples/shapes/02-bouncing-ball.lisp
@@ -49,21 +49,21 @@
                                                        :size 30
                                                        :color +gray+))))))
       (with-scene scene ()
-        (do-game-loop (:livesupport t
-                       :vars ((pause nil)
-                              (frames-counter 0)))
-          (when (is-key-pressed-p +key-space+)
-            (setf pause (not pause)))
+        (with-scene-objects (ball) scene
+          (do-game-loop (:livesupport t
+                         :vars ((pause nil)
+                                (frames-counter 0)))
+            (when (is-key-pressed-p +key-space+)
+              (setf pause (not pause)))
 
-          (with-scene-objects (ball) scene
             (if (not pause)
                 (progn
                   (move-ball ball)
                   (bounce-ball ball (get-screen-width) (get-screen-height)))
-                (incf frames-counter)))
+                (incf frames-counter))
 
-          (with-drawing
-            (if (and pause (= 0 (mod (truncate frames-counter 30) 2)))
-                (draw-scene-all scene)
-                (draw-scene-except scene 'text-pause))
-            (draw-fps 10 10)))))))
+            (with-drawing
+              (if (and pause (= 0 (mod (truncate frames-counter 30) 2)))
+                  (draw-scene-all scene)
+                  (draw-scene-except scene 'text-pause))
+              (draw-fps 10 10))))))))

--- a/examples/shapes/03-colors-palette.lisp
+++ b/examples/shapes/03-colors-palette.lisp
@@ -1,0 +1,90 @@
+(in-package #:claylib/examples)
+
+(defun check-collision-point-rec (point rectangle)
+  "Check if POINT is inside RECTANGLE.
+TODO Is there an easier way using CLAYLIB/LL:CHECK-COLLISION-POINT-REC?"
+  (let ((width (width rectangle))
+        (height (height rectangle))
+        (x (x rectangle))
+        (y (y rectangle)))
+    (and
+     (< x (x point) (+ x width))
+     (< y (y point) (+ y height)))))
+
+(defun example-shapes-03 ()
+  (with-window (:title "raylib [shapes] example - Colors pallete")
+    (let* ((colors (list +darkgray+ +maroon+ +orange+ +darkgreen+ +darkblue+ +darkpurple+
+                         +darkbrown+ +gray+ +red+ +gold+ +lime+ +blue+ +violet+ +brown+ +lightgray+
+                         +pink+ +yellow+ +green+ +skyblue+ +purple+ +beige+))
+           (color-names '("DARKGRAY" "MAROON" "ORANGE" "DARKGREEN" "DARKBLUE" "DARKPURPLE"
+                          "DARKBROWN" "GRAY" "RED" "GOLD" "LIME" "BLUE" "VIOLET" "BROWN" "LIGHTGRAY"
+                          "PINK" "YELLOW" "GREEN" "SKYBLUE" "PURPLE" "BEIGE"))
+           (color-recs (loop for color in colors
+                             for i = 0 then (1+ i)
+                             collect (make-rectangle
+                                      (+ 20
+                                         (* 100 (mod i 7))
+                                         (* 10 (mod i 7)))
+                                      (+ 80
+                                         (* 100 (truncate i 7))
+                                         (* 10 (truncate i 7)))
+                                      100
+                                      100
+                                      color)))
+           (scene (make-scene ()
+                              `((text ,(make-text "claylib colors palette"
+                                                  28
+                                                  42
+                                                  :size 20
+                                                  :color +black+))
+                                (text-space ,(make-text "press SPACE to see all colors"
+                                                        (- (get-screen-width) 180)
+                                                        (- (get-screen-height) 40)
+                                                        :size 10
+                                                        :color +gray+))))))
+      (with-scene scene ()
+        (do-game-loop (:livesupport t
+                       :vars ((color-state (make-array (length colors)
+                                                       :element-type 'bit
+                                                       :initial-element 0))
+                              (mouse-point (make-vector2 0 0))
+                              (faded-rect-color nil)))
+          (setf mouse-point (get-mouse-position mouse-point))
+
+          ;; restore original color if there was a faded rect
+          (when faded-rect-color
+            (setf (color (car faded-rect-color)) (cdr faded-rect-color)
+                  faded-rect-color nil))
+
+          (with-drawing
+            (draw-scene-all scene)
+            (loop for rect in color-recs
+                  for i from 0 below (length color-recs)
+                  for mouse-over-p = (check-collision-point-rec mouse-point rect)
+                  do (when mouse-over-p
+                       (setf faded-rect-color `(,rect . ,(color rect))) ; remember fade
+                       (setf (color rect) (fade (color rect) 0.6 t)))
+                     (draw-object rect)
+                     (when (or (is-key-down-p +key-space+) mouse-over-p)
+                       (draw-object (make-rectangle (x rect)
+                                                    (+ (y rect)
+                                                       (height rect)
+                                                       (- 26))
+                                                    (width rect)
+                                                    20
+                                                    +black+))
+                       (draw-object (make-rectangle (x rect)
+                                                    (y rect)
+                                                    (width rect)
+                                                    (height rect)
+                                                    (fade +black+ 0.3 t)
+                                                    :filled nil
+                                                    :thickness 6))
+                       (draw-object (make-text (nth i color-names)
+                                               (+ (x rect)
+                                                  (width rect)
+                                                  (- (measure-text (nth i color-names) 10))
+                                                  (- 12))
+                                               (+ (y rect) (height rect) (- 20))
+                                               :size 10
+                                               :color (nth i colors)))))))))))

--- a/examples/shapes/03-colors-palette.lisp
+++ b/examples/shapes/03-colors-palette.lisp
@@ -31,6 +31,33 @@ TODO Is there an easier way using CLAYLIB/LL:CHECK-COLLISION-POINT-REC?"
                                       100
                                       100
                                       color)))
+           (black-recs (loop for rect in color-recs
+                             collect (make-rectangle (x rect)
+                                                     (+ (y rect)
+                                                        (height rect)
+                                                        (- 26))
+                                                     (width rect)
+                                                     20
+                                                     +black+)))
+           (outline-recs (loop for rect in color-recs
+                               collect (make-rectangle (x rect)
+                                                       (y rect)
+                                                       (width rect)
+                                                       (height rect)
+                                                       (fade +black+ 0.3 t)
+                                                       :filled nil
+                                                       :thickness 6)))
+           (text-labels (loop for rect in color-recs
+                              for color in colors
+                              for color-name in color-names
+                              collect (make-text color-name
+                                                 (+ (x rect)
+                                                    (width rect)
+                                                    (- (measure-text color-name 10))
+                                                    (- 12))
+                                                 (+ (y rect) (height rect) (- 20))
+                                                 :size 10
+                                                 :color color)))
            (scene (make-scene ()
                               `((text ,(make-text "claylib colors palette"
                                                   28
@@ -59,6 +86,9 @@ TODO Is there an easier way using CLAYLIB/LL:CHECK-COLLISION-POINT-REC?"
           (with-drawing
             (draw-scene-all scene)
             (loop for rect in color-recs
+                  for black-rect in black-recs
+                  for outline-rect in outline-recs
+                  for label in text-labels
                   for i from 0 below (length color-recs)
                   for mouse-over-p = (check-collision-point-rec mouse-point rect)
                   do (when mouse-over-p
@@ -66,25 +96,6 @@ TODO Is there an easier way using CLAYLIB/LL:CHECK-COLLISION-POINT-REC?"
                        (setf (color rect) (fade (color rect) 0.6 t)))
                      (draw-object rect)
                      (when (or (is-key-down-p +key-space+) mouse-over-p)
-                       (draw-object (make-rectangle (x rect)
-                                                    (+ (y rect)
-                                                       (height rect)
-                                                       (- 26))
-                                                    (width rect)
-                                                    20
-                                                    +black+))
-                       (draw-object (make-rectangle (x rect)
-                                                    (y rect)
-                                                    (width rect)
-                                                    (height rect)
-                                                    (fade +black+ 0.3 t)
-                                                    :filled nil
-                                                    :thickness 6))
-                       (draw-object (make-text (nth i color-names)
-                                               (+ (x rect)
-                                                  (width rect)
-                                                  (- (measure-text (nth i color-names) 10))
-                                                  (- 12))
-                                               (+ (y rect) (height rect) (- 20))
-                                               :size 10
-                                               :color (nth i colors)))))))))))
+                       (draw-object black-rect)
+                       (draw-object outline-rect)
+                       (draw-object label)))))))))

--- a/examples/shapes/03-colors-palette.lisp
+++ b/examples/shapes/03-colors-palette.lisp
@@ -49,7 +49,7 @@ TODO Is there an easier way using CLAYLIB/LL:CHECK-COLLISION-POINT-REC?"
                                                        :initial-element 0))
                               (mouse-point (make-vector2 0 0))
                               (faded-rect-color nil)))
-          (setf mouse-point (get-mouse-position mouse-point))
+          (get-mouse-position mouse-point)
 
           ;; restore original color if there was a faded rect
           (when faded-rect-color

--- a/ll/package.lisp
+++ b/ll/package.lisp
@@ -21,6 +21,7 @@
    :clear-background :begin-drawing :end-drawing :begin-mode2d :end-mode2d :begin-mode3d :end-mode3d
    :begin-texture-mode :end-texture-mode :begin-shader-mode :end-shader-mode :begin-blend-mode
    :end-blend-mode :begin-scissor-mode :end-scissor-mode :begin-vr-stereo-mode :end-vr-stereo-mode
+   :swap-screen-buffer
 
    ;; VR stereo config functions for VR simulator
    :load-vr-stereo-config :unload-vr-stereo-config
@@ -35,7 +36,7 @@
    :get-world-to-screen2d :get-screen-to-world2d
 
    ;; Timing-related functions
-   :set-target-fps :get-fps :get-frame-time :get-time
+   :set-target-fps :get-fps :get-frame-time :get-time :wait-time
 
    ;; Misc. functions
    :get-random-value :set-random-seed :take-screenshot :set-config-flags :trage-log :set-trace-log

--- a/src/circle.lisp
+++ b/src/circle.lisp
@@ -9,20 +9,29 @@
 
 (definitializer-float circle radius)
 
-(defun make-circle (x y radius color &key (filled t))
+(defun make-circle (x y radius color &key (color2 nil) (filled t))
   (make-instance 'circle
                  :pos (make-vector2 x y)
                  :radius radius
                  :color color
+                 :color2 color2
                  :filled filled))
 
 (defmethod draw-object ((obj circle))
-  (if (filled obj)
-      (claylib/ll:draw-circle-v (c-struct (pos obj))
+  (cond
+    ((and (filled obj) (color2 obj))
+     (claylib/ll:draw-circle-gradient (truncate (x obj))
+                                      (truncate (y obj))
+                                      (radius obj)
+                                      (c-struct (color obj))
+                                      (c-struct (color2 obj))))
+    ((filled obj)
+     (claylib/ll:draw-circle-v (c-struct (pos obj))
                                 (radius obj)
-                                (c-struct (color obj)))
-      ;; There's no DRAW-CIRCLE-LINES-V, so we have to use ints :-(
+                                (c-struct (color obj))))
+    (t
+     ;; There's no DRAW-CIRCLE-LINES-V, so we have to use ints :-(
       (claylib/ll:draw-circle-lines (truncate (x obj))
                                     (truncate (y obj))
                                     (radius obj)
-                                    (c-struct (color obj)))))
+                                    (c-struct (color obj))))))

--- a/src/scene.lisp
+++ b/src/scene.lisp
@@ -71,10 +71,12 @@
     (draw-object (scene-object scene obj))))
 
 (defun draw-scene-all (scene)
+  "Draw all the objects in the given SCENE."
   (dolist (obj (nreverse (alexandria:hash-table-values (objects scene))))
     (draw-object obj)))
 
 (defun draw-scene-except (scene &rest names)
+  "Draw all the objects in the given SCENE except those specified as one of NAMES."
   (dolist (obj (remove-if (lambda (kv)
                             (member (car kv) names))
                           (nreverse (alexandria:hash-table-alist (objects scene)))))

--- a/src/shape.lisp
+++ b/src/shape.lisp
@@ -16,5 +16,10 @@
 
 
 
-(defclass 2d-shape (shape 2d-object) ())
+(defclass 2d-shape (shape 2d-object)
+  ((%color2 :initarg :color2
+            :initform nil
+            :type (or rl-color null)
+            :accessor color2)))
+
 (defclass 3d-shape (shape 3d-object) ())


### PR DESCRIPTION
Note: shapes example 1 is lacking triangles. I figured it would be better to show off that example using only claylib objects.