### PR TITLE
Package-ify examples

### DIFF
--- a/examples/core/01-window.lisp
+++ b/examples/core/01-window.lisp
@@ -1,6 +1,10 @@
-(in-package #:claylib/examples)
+(in-package #:cl-user)
+(defpackage claylib/examples/core-1
+  (:use :cl :claylib)
+  (:export :main))
+(in-package #:claylib/examples/core-1)
 
-(defun example-core-01 ()
+(defun main ()
   (with-window (:title "raylib [core] example - basic window")
     (let ((scene (make-scene ()
                              `((text ,(make-text "Congrats! You created your first window!"
@@ -12,4 +16,3 @@
         (do-game-loop (:livesupport t)
           (with-drawing
             (draw-scene-all scene)))))))
-

--- a/examples/core/02-manager.lisp
+++ b/examples/core/02-manager.lisp
@@ -1,4 +1,8 @@
-(in-package #:claylib/examples)
+(in-package #:cl-user)
+(defpackage claylib/examples/core-2
+  (:use :cl :claylib)
+  (:export :main))
+(in-package #:claylib/examples/core-2)
 
 (defun next-screen ()
    "Is user indicating we can move to the next stage?"
@@ -9,7 +13,7 @@
 (defun make-screen (color)
   (make-rectangle 0 0 *screen-width* *screen-height* color))
 
-(defun example-core-02 ()
+(defun main ()
   (with-window (:title "raylib [core] example - basic screen manager")
     (let ((logo (make-scene () `((paint ,(make-screen *claylib-background*))
                                  (text ,(make-text "LOGO SCREEN" 20 20

--- a/examples/core/03-keyboard.lisp
+++ b/examples/core/03-keyboard.lisp
@@ -1,4 +1,8 @@
-(in-package #:claylib/examples)
+(in-package #:cl-user)
+(defpackage claylib/examples/core-3
+  (:use :cl :claylib)
+  (:export :main))
+(in-package #:claylib/examples/core-3)
 
 (defmacro reposition (coord ball crsr delta)
   "Repositions X coordinate if the specified cursor key is pressed."
@@ -15,7 +19,7 @@
   (reposition y ball +key-up+    -2.0)
   (reposition y ball +key-down+  +2.0))
 
-(defun example-core-03 ()
+(defun main ()
   (with-window (:title "raylib [core] example - keyboard input")
     (let ((scene (make-scene () `((text ,(make-text "Move the ball with arrow keys"
                                                     10 10

--- a/examples/core/04-mouse.lisp
+++ b/examples/core/04-mouse.lisp
@@ -1,4 +1,9 @@
-(in-package #:claylib/examples)
+(in-package #:cl-user)
+(defpackage claylib/examples/core-4
+  (:use :cl :claylib)
+  (:export :main))
+(in-package #:claylib/examples/core-4)
+
 
 (defun colorize (clr)
   "Determines current color based on mouse actions."
@@ -8,7 +13,7 @@
     ((is-mouse-button-pressed-p +mouse-button-middle+)  +lime+)
     (t clr)))
 
-(defun example-core-04 ()
+(defun main ()
   (with-window (:title "raylib [core] example - mouse input")
     (let ((scene (make-scene ()
                              `((text ,(make-text "" 10 10 :size 20 :color +darkgray+))

--- a/examples/core/05-mouse-wheel.lisp
+++ b/examples/core/05-mouse-wheel.lisp
@@ -1,6 +1,10 @@
-(in-package #:claylib/examples)
+(in-package #:cl-user)
+(defpackage claylib/examples/core-5
+  (:use :cl :claylib)
+  (:export :main))
+(in-package #:claylib/examples/core-5)
 
-(defun example-core-05 ()
+(defun main ()
   (with-window (:title "raylib [core] example - input mouse wheel")
     (let ((scene
             (make-scene ()

--- a/examples/core/09-2d-camera.lisp
+++ b/examples/core/09-2d-camera.lisp
@@ -1,6 +1,11 @@
-(in-package #:claylib/examples)
+(in-package #:cl-user)
+(defpackage claylib/examples/core-9
+  (:use :cl :claylib)
+  (:export :main))
+(in-package #:claylib/examples/core-9)
 
-(defun example-core-09 ()
+
+(defun main ()
   (with-window (:title "raylib [core] example - 2d camera")
     (let* ((camera (make-camera-2d (/ *screen-width* 2.0)
                                    (/ *screen-height* 2.0)

--- a/examples/core/10-2d-camera-platformer.lisp
+++ b/examples/core/10-2d-camera-platformer.lisp
@@ -1,4 +1,10 @@
-(in-package #:claylib/examples)
+(in-package #:cl-user)
+(defpackage claylib/examples/core-10
+  (:use :cl :claylib)
+  (:import-from :alexandria
+                :circular-list)
+  (:export :main))
+(in-package #:claylib/examples/core-10)
 
 (defclass player (rectangle)
   ((%speed :initarg :spd
@@ -13,14 +19,14 @@
                 :type boolean
                 :accessor blocking-p)))
 
-(defclass example-core-10-camera (rl-camera-2d)
-  ((%mode :initform (alexandria:circular-list :center
+(defclass camera (rl-camera-2d)
+  ((%mode :initform (circular-list :center
                                               :center-inside-map
                                               :center-smooth-follow
                                               :even-out-on-landing
                                               :player-bounds-push))
    (%mode-desc :initform
-               (alexandria:circular-list "Follow player center"
+               (circular-list "Follow player center"
                                          "Follow player center, but clamp to map edges"
                                          "Follow player center; smoothed"
                                          "Follow player center horizontally; update player center vertically after landing"
@@ -35,10 +41,10 @@
                      :type float
                      :accessor even-out-target)))
 
-(defmethod mode ((camera example-core-10-camera))
+(defmethod mode ((camera camera))
   (car (slot-value camera '%mode)))
 
-(defmethod mode-desc ((camera example-core-10-camera))
+(defmethod mode-desc ((camera camera))
   (car (slot-value camera '%mode-desc)))
 
 (defun next-mode (camera)
@@ -170,7 +176,7 @@
                  :blocking-p blocking-p
                  :color color))
 
-(defun example-core-10 ()
+(defun main ()
   (with-window (:title "raylib [core] example - 2d camera")
     (let* ((scene
              (make-scene ()
@@ -206,7 +212,7 @@
                             (make-env-item 300 200 400 10 t +gray+)
                             (make-env-item 250 300 100 10 t +gray+)
                             (make-env-item 650 300 100 10 t +gray+)))
-           (camera (make-instance 'example-core-10-camera
+           (camera (make-instance 'camera
                                   :target (make-vector2 (+ (x (scene-object scene 'player)) 20)
                                                         (+ (y (scene-object scene 'player)) 40))
                                   :offset (make-vector2 (/ *screen-width* 2.0)

--- a/examples/core/11-3d-camera.lisp
+++ b/examples/core/11-3d-camera.lisp
@@ -1,6 +1,10 @@
-(in-package #:claylib/examples)
+(in-package #:cl-user)
+(defpackage claylib/examples/core-11
+  (:use :cl :claylib)
+  (:export :main))
+(in-package #:claylib/examples/core-11)
 
-(defun example-core-11 ()
+(defun main ()
   (with-window (:title "raylib [core] example - 3d camera mode")
     (let ((camera (make-camera-3d 0 10 10
                                   0 0 0

--- a/examples/core/12-3d-camera-free.lisp
+++ b/examples/core/12-3d-camera-free.lisp
@@ -1,6 +1,10 @@
-(in-package #:claylib/examples)
+(in-package #:cl-user)
+(defpackage claylib/examples/core-12
+  (:use :cl :claylib)
+  (:export :main))
+(in-package #:claylib/examples/core-12)
 
-(defun example-core-12 ()
+(defun main ()
   (with-window (:title "raylib [core] example - 3d camera free")
     (let ((camera (make-camera-3d 10 10 10
                                   0 0 0

--- a/examples/core/13-3d-camera-first-person.lisp
+++ b/examples/core/13-3d-camera-first-person.lisp
@@ -1,6 +1,10 @@
-(in-package #:claylib/examples)
+(in-package #:cl-user)
+(defpackage claylib/examples/core-13
+  (:use :cl :claylib)
+  (:export :main))
+(in-package #:claylib/examples/core-13)
 
-(defun example-core-13 ()
+(defun main ()
   (with-window (:title "raylib [core] example - 3d camera first person")
     (let ((camera (make-camera-3d 4 2 4
                                   0 1.8 0

--- a/examples/core/14-3d-picking.lisp
+++ b/examples/core/14-3d-picking.lisp
@@ -1,6 +1,10 @@
-(in-package #:claylib/examples)
+(in-package #:cl-user)
+(defpackage claylib/examples/core-14
+  (:use :cl :claylib)
+  (:export :main))
+(in-package #:claylib/examples/core-14)
 
-(defun example-core-14 ()
+(defun main ()
   (with-window (:title "raylib [core] example - 3d picking")
     (let ((camera (make-camera-3d 10 10 10
                                   0 0 0

--- a/examples/core/15-world-screen.lisp
+++ b/examples/core/15-world-screen.lisp
@@ -1,6 +1,10 @@
-(in-package #:claylib/examples)
+(in-package #:cl-user)
+(defpackage claylib/examples/core-15
+  (:use :cl :claylib)
+  (:export :main))
+(in-package #:claylib/examples/core-15)
 
-(defun example-core-15 ()
+(defun main ()
   (with-window (:title "raylib [core] example - 3d camera free")
     (let* ((half-text (/ (measure-text "Enemy: 100 / 100" 20) 2.0))
            (camera (make-camera-3d 10 10 10

--- a/examples/core/17-window-letterbox.lisp
+++ b/examples/core/17-window-letterbox.lisp
@@ -1,4 +1,8 @@
-(in-package #:claylib/examples)
+(in-package #:cl-user)
+(defpackage claylib/examples/core-17
+  (:use :cl :claylib)
+  (:export :main))
+(in-package #:claylib/examples/core-17)
 
 (defun clamp-vector2 (vec min max &optional allocate-p)
   (let ((vec (if allocate-p (make-vector2 (x vec) (y vec)) vec)))
@@ -13,7 +17,7 @@
                               (get-random-value 50 150)
                               (get-random-value 10 100))))
 
-(defun example-core-17 ()
+(defun main ()
   (with-window (:title "raylib [core] example - window scale letterbox"
                 :flags `(,+flag-window-resizable+ ,+flag-vsync-hint+)
                 :min-size (320 240))

--- a/examples/core/19-random-values.lisp
+++ b/examples/core/19-random-values.lisp
@@ -1,6 +1,10 @@
-(in-package #:claylib/examples)
+(in-package #:cl-user)
+(defpackage claylib/examples/core-19
+  (:use :cl :claylib)
+  (:export :main))
+(in-package #:claylib/examples/core-19)
 
-(defun example-core-19 ()
+(defun main ()
   (with-window (:title "raylib [core] example - generate random values")
     (let* ((rand-value (get-random-value -8 5))
            (frames-counter 0)

--- a/examples/core/20-scissor-test.lisp
+++ b/examples/core/20-scissor-test.lisp
@@ -1,6 +1,10 @@
-(in-package #:claylib/examples)
+(in-package #:cl-user)
+(defpackage claylib/examples/core-20
+  (:use :cl :claylib)
+  (:export :main))
+(in-package #:claylib/examples/core-20)
 
-(defun example-core-20 ()
+(defun main ()
   (with-window (:title "raylib [core] example - scissor test")
     (let ((scissor-area (make-instance 'rl-rectangle :x 0 :y 0 :width 300 :height 300))
           (scissor-mode t)

--- a/examples/core/21-storage-values.lisp
+++ b/examples/core/21-storage-values.lisp
@@ -1,6 +1,10 @@
-(in-package #:claylib/examples)
+(in-package #:cl-user)
+(defpackage claylib/examples/core-21
+  (:use :cl :claylib)
+  (:export :main))
+(in-package #:claylib/examples/core-21)
 
-(defun example-core-21 ()
+(defun main ()
   (with-window (:title "raylib [core] example - storage save/load values")
     (let ((score 0)
           (hiscore 0)

--- a/examples/core/24-quat-conversion.lisp
+++ b/examples/core/24-quat-conversion.lisp
@@ -1,6 +1,10 @@
-(in-package #:claylib/examples)
+(in-package #:cl-user)
+(defpackage claylib/examples/core-24
+  (:use :cl :claylib)
+  (:export :main))
+(in-package #:claylib/examples/core-24)
 
-(defun example-core-24 ()
+(defun main ()
   (with-window (:title "raylib [core] example - quat conversions")
     (let ((camera (make-camera-3d 0 10 10
                                   0 0 0

--- a/examples/core/25-window-flags.lisp
+++ b/examples/core/25-window-flags.lisp
@@ -1,4 +1,8 @@
-(in-package #:claylib/examples)
+(in-package #:cl-user)
+(defpackage claylib/examples/core-25
+  (:use :cl :claylib)
+  (:export :main))
+(in-package #:claylib/examples/core-25)
 
 (defclass ball (circle)
   ((%speed :initarg :speed
@@ -20,7 +24,7 @@
       (setf (text obj) (format nil "~A: off" text)
             (color obj) +maroon+)))
 
-(defun example-core-25 ()
+(defun main ()
   (with-window (:title "raylib [core] example - window flags")
     (let ((scene (make-scene ()
                              `((ball ,(make-instance 'ball
@@ -60,7 +64,7 @@
             (toggle-fullscreen))
           (toggle-flag +key-r+ +flag-window-resizable+)
           (toggle-flag +key-d+ +flag-window-undecorated+)
-          
+
           (when (is-key-pressed-p +key-h+)
             (unless (is-window-state-p +flag-window-hidden+)
               (set-window-state +flag-window-hidden+))

--- a/examples/core/26-split-screen.lisp
+++ b/examples/core/26-split-screen.lisp
@@ -1,6 +1,10 @@
-(in-package #:claylib/examples)
+(in-package #:cl-user)
+(defpackage claylib/examples/core-26
+  (:use :cl :claylib)
+  (:export :main))
+(in-package #:claylib/examples/core-26)
 
-(defun example-core-26 ()
+(defun main ()
   (with-window (:title "raylib [core] example - split screen")
     (let* ((texture-grid (make-instance 'texture
                                         :filter +texture-filter-anisotropic-16x+
@@ -82,7 +86,7 @@
 
           (setf (pos (scene-object scene 'player1)) (pos camera-player1)
                 (pos (scene-object scene 'player2)) (pos camera-player2))
-          
+
           (let ((*claylib-background* +skyblue+))
             (with-texture-mode screen-player1
               (with-3d-mode camera-player1

--- a/examples/core/27-smooth-pixelperfect.lisp
+++ b/examples/core/27-smooth-pixelperfect.lisp
@@ -1,6 +1,10 @@
-(in-package #:claylib/examples)
+(in-package #:cl-user)
+(defpackage claylib/examples/core-27
+  (:use :cl :claylib)
+  (:export :main))
+(in-package #:claylib/examples/core-27)
 
-(defun example-core-27 ()
+(defun main ()
   (with-window (:title "raylib [core] example - smooth pixel-perfect camera")
     (let* ((virtual-screen-width 160)
            (virtual-screen-height 90)

--- a/examples/core/28-custom-frame-control.lisp
+++ b/examples/core/28-custom-frame-control.lisp
@@ -1,6 +1,10 @@
-(in-package #:claylib/examples)
+(in-package #:cl-user)
+(defpackage claylib/examples/core-28
+  (:use :cl :claylib)
+  (:export :main))
+(in-package #:claylib/examples/core-28)
 
-(defun example-core-28 ()
+(defun main ()
   (with-window (:title "raylib [core] example - custom frame control")
     (let ((scene
             (make-scene ()

--- a/examples/shapes/01-basic-shapes.lisp
+++ b/examples/shapes/01-basic-shapes.lisp
@@ -1,6 +1,10 @@
-(in-package #:claylib/examples)
+(in-package #:cl-user)
+(defpackage claylib/examples/shapes-1
+  (:use :cl :claylib)
+  (:export :main))
+(in-package #:claylib/examples/shapes-1)
 
-(defun example-shapes-01 ()
+(defun main ()
   (with-window (:title "raylib [shapes] example - Draw basic shapes 2d (rectangle, circle, line...)")
     (let ((scene (make-scene ()
                              `((text-title ,(make-text "some basic shapes available on raylib"

--- a/examples/shapes/02-bouncing-ball.lisp
+++ b/examples/shapes/02-bouncing-ball.lisp
@@ -1,4 +1,8 @@
-(in-package #:claylib/examples)
+(in-package #:cl-user)
+(defpackage claylib/examples/shapes-2
+  (:use :cl :claylib)
+  (:export :main))
+(in-package #:claylib/examples/shapes-2)
 
 (defclass ball (circle)
   ((%speed :initarg :speed
@@ -30,7 +34,7 @@ components of the BALL's SPEED."
     (when (or (>= y (- screen-height radius)) (<= y radius))
       (setf (y (spd ball)) (- (y (spd ball)))))))
 
-(defun example-shapes-02 ()
+(defun main ()
   (with-window (:title "raylib [shapes] example - bouncing ball")
     (let ((scene (make-scene ()
                              `((ball ,(make-ball (/ (get-screen-width) 2.0)

--- a/examples/shapes/03-colors-palette.lisp
+++ b/examples/shapes/03-colors-palette.lisp
@@ -1,6 +1,10 @@
-(in-package #:claylib/examples)
+(in-package #:cl-user)
+(defpackage claylib/examples/shapes-3
+  (:use :cl :claylib)
+  (:export :main))
+(in-package #:claylib/examples/shapes-3)
 
-(defun example-shapes-03 ()
+(defun main ()
   (with-window (:title "raylib [shapes] example - Colors pallete")
     (let* ((colors (list +darkgray+ +maroon+ +orange+ +darkgreen+ +darkblue+ +darkpurple+
                          +darkbrown+ +gray+ +red+ +gold+ +lime+ +blue+ +violet+ +brown+ +lightgray+


### PR DESCRIPTION
All examples can now be run with, for example, `(claylib/examples/core-1:main)`