### PR TITLE
Possibly easier use of multiple scenes

### DIFF
--- a/claylib.asd
+++ b/claylib.asd
@@ -79,7 +79,7 @@
   :license "TODO"
   :version "0.0.1"
   :serial t
-  :depends-on (#:claylib)
+  :depends-on (#:claylib #:alexandria)
   :components ((:module "examples"
                 :components
                 ((:file "package")

--- a/examples/core/01-window.lisp
+++ b/examples/core/01-window.lisp
@@ -4,15 +4,16 @@
   (:export :main))
 (in-package #:claylib/examples/core-1)
 
+(defparameter *scene* (make-scene ()
+                                  ((text (make-text "Congrats! You created your first window!"
+                                                    190
+                                                    200
+                                                    :size 20
+                                                    :color +lightgray+)))))
+
 (defun main ()
   (with-window (:title "raylib [core] example - basic window")
-    (let ((scene (make-scene ()
-                             ((text (make-text "Congrats! You created your first window!"
-                                               190
-                                               200
-                                               :size 20
-                                               :color +lightgray+))))))
-      (with-scene scene ()
-        (do-game-loop (:livesupport t)
-          (with-drawing
-            (draw-scene-all scene)))))))
+    (with-scenes *scene*
+      (do-game-loop (:livesupport t)
+        (with-drawing
+          (draw-scene-all *scene*))))))

--- a/examples/core/02-manager.lisp
+++ b/examples/core/02-manager.lisp
@@ -45,14 +45,12 @@
 
 (defun main ()
   (with-window (:title "raylib [core] example - basic screen manager")
-    (do-game-loop (:livesupport t
-                   :scene *logo*
-                   :vars ((scenes `(,*logo* ,@(alexandria:circular-list *title* *gameplay* *ending*)))
-                          (frame-count 0)))
-      (incf frame-count)
-      (when (or (and (next-screen) (not (eql (car scenes) *logo*)))
-                (and (eql (car scenes) *logo*) (> frame-count (* 2 *target-fps*))))
-        (setf scenes (cdr scenes))
-        (switch-scene (car scenes)))
-      (with-drawing (draw-scene-all *scene*)))
-    (mapcar #'unload-scene-all (list *logo* *title* *gameplay* *ending*))))
+    (with-scenes (list *logo* *title* *gameplay* *ending*)
+      (do-game-loop (:livesupport t
+                     :vars ((scenes `(,*logo* ,@(alexandria:circular-list *title* *gameplay* *ending*)))
+                            (frame-count 0)))
+        (incf frame-count)
+        (when (or (and (next-screen) (not (eql (car scenes) *logo*)))
+                  (and (eql (car scenes) *logo*) (> frame-count (* 2 *target-fps*))))
+          (setf scenes (cdr scenes)))
+        (with-drawing (draw-scene-all (car scenes)))))))

--- a/examples/core/02-manager.lisp
+++ b/examples/core/02-manager.lisp
@@ -7,35 +7,41 @@
 (defun make-screen (color)
   (make-rectangle 0 0 *screen-width* *screen-height* color))
 
-(defparameter *logo* (make-scene () ((paint (make-screen *claylib-background*))
-                                     (text (make-text "LOGO SCREEN" 20 20
-                                                      :size 40 :color +lightgray+))
-                                     (subtext (make-text "WAIT for 2 SECONDS..." 290 220
-                                                         :size 20 :color +gray+)))))
+(defparameter *logo* (make-scene () () ((paint (make-screen *claylib-background*))
+                                        (text (make-text "LOGO SCREEN" 20 20
+                                                         :size 40 :color +lightgray+))
+                                        (subtext (make-text "WAIT for 2 SECONDS..." 290 220
+                                                            :size 20 :color +gray+)))))
 
-(defparameter *title* (make-scene () ((paint (make-screen +green+))
-                                      (text (make-text "TITLE SCREEN" 20 20
-                                                       :size 40 :color +darkgreen+))
-                                      (subtext (make-text "PRESS ENTER or TAP to JUMP to GAMEPLAY SCREEN"
-                                                          120 220
-                                                          :size 20 :color +darkgreen+)))))
+(defparameter *title* (make-scene (:free :later)
+                                  ()
+                                  ((paint (make-screen +green+))
+                                   (text (make-text "TITLE SCREEN" 20 20
+                                                    :size 40 :color +darkgreen+))
+                                   (subtext (make-text "PRESS ENTER or TAP to JUMP to GAMEPLAY SCREEN"
+                                                       120 220
+                                                       :size 20 :color +darkgreen+)))))
 
-(defparameter *gameplay* (make-scene () ((paint (make-screen +purple+))
-                                         (text (make-text "GAMEPLAY SCREEN" 20 20
-                                                          :size 40 :color +maroon+))
-                                         (subtext (make-text "PRESS ENTER or TAP to JUMP to ENDING SCREEN"
-                                                             130 220
-                                                             :size 20 :color +maroon+)))))
+(defparameter *gameplay* (make-scene (:free :later)
+                                     ()
+                                     ((paint (make-screen +purple+))
+                                      (text (make-text "GAMEPLAY SCREEN" 20 20
+                                                       :size 40 :color +maroon+))
+                                      (subtext (make-text "PRESS ENTER or TAP to JUMP to ENDING SCREEN"
+                                                          130 220
+                                                          :size 20 :color +maroon+)))))
 
-(defparameter *ending* (make-scene () ((paint (make-screen +blue+))
-                                       (text (make-text "ENDING SCREEN" 20 20
-                                                        :size 40 :color +darkblue+))
-                                       (subtext (make-text "PRESS ENTER or TAP to RETURN to TITLE SCREEN"
-                                                           120 220
-                                                           :size 20 :color +darkblue+)))))
+(defparameter *ending* (make-scene (:free :later)
+                                   ()
+                                   ((paint (make-screen +blue+))
+                                    (text (make-text "ENDING SCREEN" 20 20
+                                                     :size 40 :color +darkblue+))
+                                    (subtext (make-text "PRESS ENTER or TAP to RETURN to TITLE SCREEN"
+                                                        120 220
+                                                        :size 20 :color +darkblue+)))))
 
 (defun next-screen ()
-   "Is user indicating we can move to the next stage?"
+  "Is user indicating we can move to the next stage?"
   (or
    (is-key-pressed-p +key-enter+)
    (is-gesture-detected-p +gesture-tap+)))
@@ -43,16 +49,13 @@
 (defun main ()
   (with-window (:title "raylib [core] example - basic screen manager")
     (do-game-loop (:livesupport t
+                   :scene *logo*
                    :vars ((scenes `(,*logo* ,@(alexandria:circular-list *title* *gameplay* *ending*)))
                           (frame-count 0)))
       (incf frame-count)
       (when (or (and (next-screen) (not (eql (car scenes) *logo*)))
                 (and (eql (car scenes) *logo*) (> frame-count (* 2 *target-fps*))))
-        (setf scenes (cdr scenes)))
-      (let ((scene (car scenes)))
-        ;; TODO: Using WITH-SCENE within a game loop may be suboptimal for performance.
-        ;; It's not horrible; won't reload assets that are already loaded, for example.
-        ;; But still may cause issues with larger scenes. See #17.
-        (with-scene scene (:free :later)
-          (with-drawing (draw-scene-all scene)))))
+        (setf scenes (cdr scenes))
+        (switch-scene (car scenes)))
+      (with-drawing (draw-scene-all *scene*)))
     (mapcar #'unload-scene-all (list *logo* *title* *gameplay* *ending*))))

--- a/examples/core/02-manager.lisp
+++ b/examples/core/02-manager.lisp
@@ -7,38 +7,35 @@
 (defun make-screen (color)
   (make-rectangle 0 0 *screen-width* *screen-height* color))
 
-(defparameter *logo* (make-scene () () ((paint (make-screen *claylib-background*))
-                                        (text (make-text "LOGO SCREEN" 20 20
-                                                         :size 40 :color +lightgray+))
-                                        (subtext (make-text "WAIT for 2 SECONDS..." 290 220
-                                                            :size 20 :color +gray+)))))
+(defparameter *logo* (make-scene () ((paint (make-screen *claylib-background*))
+                                     (text (make-text "LOGO SCREEN" 20 20
+                                                      :size 40 :color +lightgray+))
+                                     (subtext (make-text "WAIT for 2 SECONDS..." 290 220
+                                                         :size 20 :color +gray+)))))
 
-(defparameter *title* (make-scene (:free :later)
-                                  ()
-                                  ((paint (make-screen +green+))
-                                   (text (make-text "TITLE SCREEN" 20 20
-                                                    :size 40 :color +darkgreen+))
-                                   (subtext (make-text "PRESS ENTER or TAP to JUMP to GAMEPLAY SCREEN"
-                                                       120 220
-                                                       :size 20 :color +darkgreen+)))))
+(defparameter *title* (make-scene () ((paint (make-screen +green+))
+                                      (text (make-text "TITLE SCREEN" 20 20
+                                                       :size 40 :color +darkgreen+))
+                                      (subtext (make-text "PRESS ENTER or TAP to JUMP to GAMEPLAY SCREEN"
+                                                          120 220
+                                                          :size 20 :color +darkgreen+)))
+                                  :free :later))
 
-(defparameter *gameplay* (make-scene (:free :later)
-                                     ()
-                                     ((paint (make-screen +purple+))
-                                      (text (make-text "GAMEPLAY SCREEN" 20 20
-                                                       :size 40 :color +maroon+))
-                                      (subtext (make-text "PRESS ENTER or TAP to JUMP to ENDING SCREEN"
-                                                          130 220
-                                                          :size 20 :color +maroon+)))))
+(defparameter *gameplay* (make-scene () ((paint (make-screen +purple+))
+                                         (text (make-text "GAMEPLAY SCREEN" 20 20
+                                                          :size 40 :color +maroon+))
+                                         (subtext (make-text "PRESS ENTER or TAP to JUMP to ENDING SCREEN"
+                                                             130 220
+                                                             :size 20 :color +maroon+)))
+                                     :free :later))
 
-(defparameter *ending* (make-scene (:free :later)
-                                   ()
-                                   ((paint (make-screen +blue+))
-                                    (text (make-text "ENDING SCREEN" 20 20
-                                                     :size 40 :color +darkblue+))
-                                    (subtext (make-text "PRESS ENTER or TAP to RETURN to TITLE SCREEN"
-                                                        120 220
-                                                        :size 20 :color +darkblue+)))))
+(defparameter *ending* (make-scene () ((paint (make-screen +blue+))
+                                       (text (make-text "ENDING SCREEN" 20 20
+                                                        :size 40 :color +darkblue+))
+                                       (subtext (make-text "PRESS ENTER or TAP to RETURN to TITLE SCREEN"
+                                                           120 220
+                                                           :size 20 :color +darkblue+)))
+                                   :free :later))
 
 (defun next-screen ()
   "Is user indicating we can move to the next stage?"

--- a/examples/core/03-keyboard.lisp
+++ b/examples/core/03-keyboard.lisp
@@ -28,7 +28,7 @@
                                                     (/ *screen-height* 2.0)
                                                     50.0
                                                     +maroon+))))))
-      (with-scene scene ()
+      (with-scenes scene
         (do-game-loop (:livesupport t)
           (move-ball (scene-object scene 'ball))
           (with-drawing

--- a/examples/core/04-mouse.lisp
+++ b/examples/core/04-mouse.lisp
@@ -18,7 +18,7 @@
     (let ((scene (make-scene ()
                              ((text (make-text "" 10 10 :size 20 :color +darkgray+))
                               (ball (make-circle -100 -100 40 +darkblue+))))))
-      (with-scene scene ()
+      (with-scenes scene
         (do-game-loop (:livesupport t
                        :vars ((color +darkblue+)))
           (with-scene-objects (ball text) scene

--- a/examples/core/05-mouse-wheel.lisp
+++ b/examples/core/05-mouse-wheel.lisp
@@ -17,7 +17,7 @@
                                           10 10
                                           :size 20 :color +gray+))
                          (subtext (make-text "" 10 40 :size 20 :color +lightgray+))))))
-      (with-scene scene ()
+      (with-scenes scene
         (do-game-loop (:livesupport t)
           (with-scene-objects (box subtext) scene
             (decf (y box) (* (get-mouse-wheel-move) 4))

--- a/examples/core/09-2d-camera.lisp
+++ b/examples/core/09-2d-camera.lisp
@@ -56,7 +56,7 @@
                                                    (get-random-value 200 240)
                                                    (get-random-value 200 250))))
                  (incf spacing w)))
-      (with-scene scene ()
+      (with-scenes scene
         (do-game-loop (:livesupport t)
           (when (is-key-down-p +key-right+) (incf (x (scene-object scene 'player)) 2))
           (when (is-key-down-p +key-left+) (decf (x (scene-object scene 'player)) 2))

--- a/examples/core/10-2d-camera-platformer.lisp
+++ b/examples/core/10-2d-camera-platformer.lisp
@@ -220,7 +220,7 @@
                                   :zoom 1.0)))
       (dolist (item env-items)
         (setf (gethash (gensym "ENV-ITEM") (objects scene)) item))
-      (with-scene scene ()
+      (with-scenes scene
         (do-game-loop (:livesupport t)
           (let ((delta (get-frame-time))
                 (player (scene-object scene 'player))

--- a/examples/core/11-3d-camera.lisp
+++ b/examples/core/11-3d-camera.lisp
@@ -20,7 +20,7 @@
                                  (text (make-text "Welcome to the third dimension!"
                                                   10 40
                                                   :size 20 :color +darkgray+))))))
-      (with-scene scene ()
+      (with-scenes scene
         (do-game-loop (:livesupport t)
           (with-drawing
             (with-3d-mode camera

--- a/examples/core/12-3d-camera-free.lisp
+++ b/examples/core/12-3d-camera-free.lisp
@@ -40,7 +40,7 @@
                                  (t6 (make-text "- Z to zoom to (0, 0, 0)"
                                                 40 120
                                                 :size 10 :color +darkgray+))))))
-      (with-scene scene ()
+      (with-scenes scene
         (do-game-loop (:livesupport t)
           (update-camera camera)
           (when (is-key-down-p +key-z+)

--- a/examples/core/13-3d-camera-first-person.lisp
+++ b/examples/core/13-3d-camera-first-person.lisp
@@ -47,7 +47,7 @@
                 (make-cube-from-vecs pos size color)
                 (gethash (gensym "COLUMN") (objects scene))
                 (make-cube-from-vecs pos size +maroon+ :filled nil))))
-      (with-scene scene ()
+      (with-scenes scene
         (do-game-loop (:livesupport t)
           (update-camera camera)
           (with-drawing

--- a/examples/core/14-3d-picking.lisp
+++ b/examples/core/14-3d-picking.lisp
@@ -40,7 +40,7 @@
           (mouse-pos (make-vector2 0 0))
           (bbox (make-instance 'rl-bounding-box :low (make-vector3 0 0 0)
                                                 :high (make-vector3 0 0 0))))
-      (with-scene scene ()
+      (with-scenes scene
         (do-game-loop (:livesupport t)
           (update-camera camera)
           (when (is-mouse-button-pressed-p +mouse-button-left+)

--- a/examples/core/15-world-screen.lisp
+++ b/examples/core/15-world-screen.lisp
@@ -38,7 +38,7 @@
                                                  :color +gray+)))))
            (invec (make-vector3 0 2.5 0))
            (outvec (make-vector2 0 0)))
-      (with-scene scene ()
+      (with-scenes scene
         (do-game-loop (:livesupport t)
           (update-camera camera)
           (get-world-to-screen-3d invec camera :vec outvec)

--- a/examples/core/17-window-letterbox.lisp
+++ b/examples/core/17-window-letterbox.lisp
@@ -62,7 +62,7 @@ and see the screen scaling!"
             (origin (texture target)) (make-vector2 0 0)
             (rot (texture target)) 0.0
             (tint (texture target)) +white+)
-      (with-scene scene ()
+      (with-scenes scene
         (do-game-loop (:livesupport t)
           (let ((scale (coerce (min (/ (get-screen-width) game-screen-width)
                                     (/ (get-screen-height) game-screen-height))

--- a/examples/core/19-random-values.lisp
+++ b/examples/core/19-random-values.lisp
@@ -15,7 +15,7 @@
                                (num (make-text (format nil "~d" rand-value)
                                                360 180
                                                :size 80 :color +lightgray+))))))
-      (with-scene scene ()
+      (with-scenes scene
         (do-game-loop (:livesupport t)
           (incf frames-counter)
           (when (= (mod (/ frames-counter 120) 2) 1)

--- a/examples/core/20-scissor-test.lisp
+++ b/examples/core/20-scissor-test.lisp
@@ -20,7 +20,7 @@
                               (text2 (make-text "Press S to toggle scissor test"
                                                 10 10
                                                 :size 20 :color +black+))))))
-      (with-scene scene ()
+      (with-scenes scene
         (do-game-loop (:livesupport t)
           (when (is-key-pressed-p +key-s+) (setf scissor-mode (not scissor-mode)))
           (setf (x scissor-area) (- (get-mouse-x) (/ (width scissor-area) 2))

--- a/examples/core/21-storage-values.lisp
+++ b/examples/core/21-storage-values.lisp
@@ -22,7 +22,7 @@
                               (text6 (make-text "Press SPACE to LOAD values"
                                                 252 350
                                                 :size 20 :color +lightgray+))))))
-      (with-scene scene ()
+      (with-scenes scene
         (do-game-loop (:livesupport t)
           (when (is-key-pressed-p +key-r+)
             (setf score (get-random-value 1000 2000)

--- a/examples/core/24-quat-conversion.lisp
+++ b/examples/core/24-quat-conversion.lisp
@@ -32,7 +32,7 @@
                               (text4 (make-text "" 200 20 :size 20))
                               (text5 (make-text "" 200 40 :size 20))
                               (text6 (make-text "" 200 60 :size 20))))))
-      (with-scene scene ()
+      (with-scenes scene
         ;; TODO: Certain GEN-MESH-* functions, including GEN-MESH-CYLINDER, are currently broken.
         (load-model-from-mesh (gen-mesh-cube 0.2 0.4 0.8)
                               :model (scene-object scene 'model))

--- a/examples/core/25-window-flags.lisp
+++ b/examples/core/25-window-flags.lisp
@@ -57,7 +57,7 @@
                               (flag-highdpi (make-text "" 10 320 :size 10))
                               (flag-transparent (make-text "" 10 340 :size 10))
                               (flag-msaa-4x-hint (make-text "" 10 360 :size 10))))))
-      (with-scene scene ()
+      (with-scenes scene
         (do-game-loop (:livesupport t
                        :vars ((frames-counter 0)))
           (when (is-key-pressed-p +key-f+)

--- a/examples/core/26-split-screen.lisp
+++ b/examples/core/26-split-screen.lisp
@@ -55,7 +55,7 @@
                                          0.25 1 0.25
                                          +brown+
                                          :texture texture-grid))))
-      (with-scene scene ()
+      (with-scenes scene
         (let ((tex1 (scene-object scene 'texture-player1))
               (tex2 (scene-object scene 'texture-player2)))
           (setf (source tex1) split-screen-rect

--- a/examples/core/27-smooth-pixelperfect.lisp
+++ b/examples/core/27-smooth-pixelperfect.lisp
@@ -32,7 +32,7 @@
                                                   10 40
                                                   :size 20 :color +darkgreen+))))))
 
-      (with-scene scene ()
+      (with-scenes scene
         (let ((tex (scene-object scene 'tex)))
           (setf (source tex) (make-instance 'rl-rectangle
                                             :x 0 :y 0

--- a/examples/core/28-custom-frame-control.lisp
+++ b/examples/core/28-custom-frame-control.lisp
@@ -55,7 +55,7 @@ independently of the frame rate."
                      (make-rectangle (* 200 i) 0
                                      1 (get-screen-height)
                                      +skyblue+)))
-      (with-scene scene ()
+      (with-scenes scene
         (do-game-loop (:livesupport t
                        :vars ((previous-time (get-time) current-time)
                               (current-time 0.0)

--- a/examples/shapes/01-basic-shapes.lisp
+++ b/examples/shapes/01-basic-shapes.lisp
@@ -71,7 +71,7 @@
                                                            +beige+
                                                            :filled nil
                                                            :thickness 6))))))
-      (with-scene scene ()
+      (with-scenes scene
         (do-game-loop (:livesupport t)
           (with-drawing
             (draw-scene-all scene)))))))

--- a/examples/shapes/02-bouncing-ball.lisp
+++ b/examples/shapes/02-bouncing-ball.lisp
@@ -53,7 +53,7 @@ components of the BALL's SPEED."
                                                      200
                                                      :size 30
                                                      :color +gray+))))))
-      (with-scene scene ()
+      (with-scenes scene
         (with-scene-objects (ball) scene
           (do-game-loop (:livesupport t
                          :vars ((pause nil)

--- a/examples/shapes/03-colors-palette.lisp
+++ b/examples/shapes/03-colors-palette.lisp
@@ -66,7 +66,7 @@
                                                       (- (get-screen-height) 40)
                                                       :size 10
                                                       :color +gray+))))))
-      (with-scene scene ()
+      (with-scenes scene
         (do-game-loop (:livesupport t
                        :vars ((mouse-point (make-vector2 0 0))
                               (faded-rect-color nil)))

--- a/examples/textures/01-logo-raylib.lisp
+++ b/examples/textures/01-logo-raylib.lisp
@@ -7,7 +7,7 @@
 (defun main ()
   (with-window (:title "raylib [textures] example - texture loading and drawing")
     (let* ((image-size 256)
-           (scene (make-scene ((texass (make-texture-asset 
+           (scene (make-scene ((texass (make-texture-asset
                                         (asdf:system-relative-pathname
                                          :claylib
                                          "examples/textures/resources/raylib_logo.png"))))
@@ -18,7 +18,7 @@
                                                 360 370
                                                 :size 10
                                                 :color +gray+))))))
-      (with-scene scene ()
+      (with-scenes scene
         (do-game-loop (:livesupport t)
           (with-drawing
             (draw-scene-all scene)))))))

--- a/examples/textures/02-mouse-painting.lisp
+++ b/examples/textures/02-mouse-painting.lisp
@@ -59,7 +59,7 @@
                                           150 180
                                           :size 20
                                           :color +raywhite+))))))
-      (with-scene scene ()
+      (with-scenes scene
         ;; Clear render texture before entering the game loop
         (with-texture-mode (target))
         (do-game-loop (:livesupport t

--- a/examples/textures/03-rectangle.lisp
+++ b/examples/textures/03-rectangle.lisp
@@ -63,7 +63,7 @@
                                                           (- (get-screen-height) 20)
                                                           :size 10
                                                           :color +gray+))))))
-      (with-scene scene ()
+      (with-scenes scene
         (do-game-loop (:livesupport t
                        :vars ((current-frame 0)
                               (frames-counter 0)

--- a/examples/textures/04-srcrec-dstrec.lisp
+++ b/examples/textures/04-srcrec-dstrec.lisp
@@ -42,7 +42,7 @@
                                                           (- (get-screen-height) 20)
                                                           :size 10
                                                           :color +gray+))))))
-      (with-scene scene ()
+      (with-scenes scene
         (do-game-loop (:livesupport t)
           (incf (rot (scene-object scene 'scarfy)))
 

--- a/examples/textures/05-image-drawing.lisp
+++ b/examples/textures/05-image-drawing.lisp
@@ -84,7 +84,7 @@
 
 (defun main ()
   (with-window (:title "raylib [textures] example - image drawing")
-  (with-scene *scene* ()
+  (with-scenes *scene*
     (do-game-loop (:livesupport t)
       (with-drawing
         (draw-scene-all *scene*))))))

--- a/package.lisp
+++ b/package.lisp
@@ -91,7 +91,7 @@
 
    ;; Scenes
    :draw-scene-all :scene-object :load-scene-all :unload-scene-all :draw-scene :draw-scene-except
-   :make-scene :objects :draw-scene-regex :with-scene :switch-scene :set-up-scene :tear-down-scene
+   :make-scene :objects :draw-scene-regex :with-scenes :set-up-scene :tear-down-scene
 
    ;; Generic functions/methods
    :x :y :z :color :target :rot :zoom :x1 :y1 :x2 :y2 :width :height :len :offset :pos :draw-object
@@ -108,7 +108,6 @@
 
    ;; Globals
    :*claylib-background* :*screen-width* :*screen-height* :*target-fps* :+claylib-directory+
-   :*scene*
 
    ;; Misc
    :draw-fps :get-random-value :get-frame-time :measure-text :get-mouse-ray :get-ray-collision-box

--- a/package.lisp
+++ b/package.lisp
@@ -91,7 +91,7 @@
 
    ;; Scenes
    :draw-scene-all :scene-object :load-scene-all :unload-scene-all :draw-scene :draw-scene-except
-   :make-scene :objects :draw-scene-regex :with-scene :switch-scene
+   :make-scene :objects :draw-scene-regex :with-scene :switch-scene :set-up-scene :tear-down-scene
 
    ;; Generic functions/methods
    :x :y :z :color :target :rot :zoom :x1 :y1 :x2 :y2 :width :height :len :offset :pos :draw-object

--- a/package.lisp
+++ b/package.lisp
@@ -76,7 +76,7 @@
    :line-2d :rl-camera-3d :camera-3d :rl-camera-2d :plane :rl-ray :ray :rl-ray-collision :rl-bounding-box
    :rl-texture :texture :rl-transform :rl-model :model :rl-mesh :rl-shader :rl-material-map :rl-material
    :rl-matrix :triangle :image-asset :texture-asset :model-asset :shader-asset :font-asset
-   :animation-asset :pixel :image
+   :animation-asset :pixel :image :game-scene
 
    ;; Misc. convenience wrappers
    :with-window :do-game-loop :with-drawing :is-key-pressed-p :is-gesture-detected-p :is-key-down-p
@@ -91,7 +91,7 @@
 
    ;; Scenes
    :draw-scene-all :scene-object :load-scene-all :unload-scene-all :draw-scene :draw-scene-except
-   :make-scene :objects :draw-scene-regex :with-scene
+   :make-scene :objects :draw-scene-regex :with-scene :switch-scene
 
    ;; Generic functions/methods
    :x :y :z :color :target :rot :zoom :x1 :y1 :x2 :y2 :width :height :len :offset :pos :draw-object
@@ -108,6 +108,7 @@
 
    ;; Globals
    :*claylib-background* :*screen-width* :*screen-height* :*target-fps* :+claylib-directory+
+   :*scene*
 
    ;; Misc
    :draw-fps :get-random-value :get-frame-time :measure-text :get-mouse-ray :get-ray-collision-box

--- a/src/claylib.lisp
+++ b/src/claylib.lisp
@@ -40,7 +40,6 @@ background of the render texture, or NIL to skip clearing."
      (end-texture-mode)))
 
 (defmacro do-game-loop ((&key
-                           (scene nil)
                            (livesupport nil)
                            (vars ())
                            (end ())
@@ -48,23 +47,16 @@ background of the render texture, or NIL to skip clearing."
                         &body body)
   "Execute a game loop.
 
-When given, this will load SCENE, enable LIVESUPPORT during execution of the loop, expose the
-bindings in VARS to the loop BODY, stop the loop when END is non-nil, and return RESULT.
-
-The current scene for a given loop is accesible via the special variable *SCENE*. To switch scenes
-inside the loop, use (SWITCH-SCENE MY-NEW-SCENE). SWITCH-SCENE loads the new scene, unloads the
-previous scene, and updates *SCENE* automatically."
-  `(let ((*scene* ,scene))
-     (set-up-scene *scene*)
-     (do ,vars ((or (window-should-close-p) ,end)
-                (tear-down-scene *scene*) ; Tear-down *SCENE* at the end of the loop
-                ,result)
-       ,@(when livesupport `((declare (notinline))))
-       ,(if livesupport
-            `(livesupport:continuable
-               ,@body
-               (livesupport:update-repl-link))
-            `(progn ,@body)))))
+When given, this will enable LIVESUPPORT during execution of the loop, expose the bindings in VARS
+to the loop BODY, stop the loop when END is non-nil, and return RESULT."
+  `(do ,vars ((or (window-should-close-p) ,end)
+              ,result)
+     ,@(when livesupport `((declare (notinline))))
+     ,(if livesupport
+          `(livesupport:continuable
+             ,@body
+             (livesupport:update-repl-link))
+          `(progn ,@body))))
 
 (defmacro with-window ((&key
                           (width *screen-width*)

--- a/src/claylib.lisp
+++ b/src/claylib.lisp
@@ -39,7 +39,6 @@ background of the render texture, or NIL to skip clearing."
      ,@body
      (end-texture-mode)))
 
-;; FIXME Problem with this approach: entering a nested do-game-loop will overwrite *SCENE*
 (defmacro do-game-loop ((&key
                            (scene nil)
                            (livesupport nil)
@@ -53,23 +52,20 @@ When given, this will load SCENE, enable LIVESUPPORT during execution of the loo
 bindings in VARS to the loop BODY, stop the loop when END is non-nil, and return RESULT.
 
 To switch scenes in the loop body, use (SWITCH-SCENE MY-NEW-SCENE). SWITCH-SCENE loads the new scene
-and unloads the previous scene automatically. The current scene is accesible via *SCENE*."
+and unloads the previous scene automatically. The current scene is accesible via the special
+variable *SCENE*."
   `(progn
-     ;; Setup the initial *SCENE* as given by SCENE
-     (when ,scene
-       (setf *scene* ,scene)
-       (set-up-scene *scene*))
-     (do ,vars ((or (window-should-close-p) ,end)
-                (tear-down-scene *scene*) ; Tear-down and reset *SCENE*
-                (setf *scene* nil)        ; at the end of the loop
-                ,result)
-       ,@(when livesupport `((declare (notinline))))
-       ;; Execute the loop body with optional livesupport
-       ,(if livesupport
-            `(livesupport:continuable
-               ,@body
-               (livesupport:update-repl-link))
-            `(progn ,@body)))))
+     (let ((*scene* ,scene))
+       (set-up-scene *scene*)
+       (do ,vars ((or (window-should-close-p) ,end)
+                  (tear-down-scene *scene*) ; Tear-down *SCENE* at the end of the loop
+                  ,result)
+         ,@(when livesupport `((declare (notinline))))
+         ,(if livesupport
+              `(livesupport:continuable
+                 ,@body
+                 (livesupport:update-repl-link))
+           `(progn ,@body))))))
 
 (defmacro with-window ((&key
                           (width *screen-width*)

--- a/src/claylib.lisp
+++ b/src/claylib.lisp
@@ -58,7 +58,7 @@ and unloads the previous scene automatically. The current scene is accesible via
      ;; Setup the initial *SCENE* as given by SCENE
      (when ,scene
        (setf *scene* ,scene)
-       (setup-scene *scene*))
+       (set-up-scene *scene*))
      (do ,vars ((or (window-should-close-p) ,end)
                 (tear-down-scene *scene*) ; Tear-down and reset *SCENE*
                 (setf *scene* nil)        ; at the end of the loop

--- a/src/claylib.lisp
+++ b/src/claylib.lisp
@@ -54,18 +54,17 @@ bindings in VARS to the loop BODY, stop the loop when END is non-nil, and return
 The current scene for a given loop is accesible via the special variable *SCENE*. To switch scenes
 inside the loop, use (SWITCH-SCENE MY-NEW-SCENE). SWITCH-SCENE loads the new scene, unloads the
 previous scene, and updates *SCENE* automatically."
-  `(progn
-     (let ((*scene* ,scene))
-       (set-up-scene *scene*)
-       (do ,vars ((or (window-should-close-p) ,end)
-                  (tear-down-scene *scene*) ; Tear-down *SCENE* at the end of the loop
-                  ,result)
-         ,@(when livesupport `((declare (notinline))))
-         ,(if livesupport
-              `(livesupport:continuable
-                 ,@body
-                 (livesupport:update-repl-link))
-           `(progn ,@body))))))
+  `(let ((*scene* ,scene))
+     (set-up-scene *scene*)
+     (do ,vars ((or (window-should-close-p) ,end)
+                (tear-down-scene *scene*) ; Tear-down *SCENE* at the end of the loop
+                ,result)
+       ,@(when livesupport `((declare (notinline))))
+       ,(if livesupport
+            `(livesupport:continuable
+               ,@body
+               (livesupport:update-repl-link))
+            `(progn ,@body)))))
 
 (defmacro with-window ((&key
                           (width *screen-width*)

--- a/src/claylib.lisp
+++ b/src/claylib.lisp
@@ -51,9 +51,9 @@ background of the render texture, or NIL to skip clearing."
 When given, this will load SCENE, enable LIVESUPPORT during execution of the loop, expose the
 bindings in VARS to the loop BODY, stop the loop when END is non-nil, and return RESULT.
 
-To switch scenes in the loop body, use (SWITCH-SCENE MY-NEW-SCENE). SWITCH-SCENE loads the new scene
-and unloads the previous scene automatically. The current scene is accesible via the special
-variable *SCENE*."
+The current scene for a given loop is accesible via the special variable *SCENE*. To switch scenes
+inside the loop, use (SWITCH-SCENE MY-NEW-SCENE). SWITCH-SCENE loads the new scene, unloads the
+previous scene, and updates *SCENE* automatically."
   `(progn
      (let ((*scene* ,scene))
        (set-up-scene *scene*)

--- a/src/generic.lisp
+++ b/src/generic.lisp
@@ -140,3 +140,6 @@ Force a reload & free old memory when FORCE-RELOAD is T."))
 
 (defgeneric tear-down-scene (scene)
   (:documentation "Free a SCENE's assets and objects."))
+
+(defgeneric switch-scene (scene)
+  (:documentation "Switch *SCENE* to SCENE, loading the new & unloading the old scene."))

--- a/src/generic.lisp
+++ b/src/generic.lisp
@@ -135,7 +135,7 @@ Force a reload & free old memory when FORCE-RELOAD is T."))
 (defgeneric image-draw (image obj)
   (:documentation "Draw an object OBJ onto the the rl-image IMAGE."))
 
-(defgeneric setup-scene (scene)
+(defgeneric set-up-scene (scene)
   (:documentation "Load a SCENE's assets and initialize its objects."))
 
 (defgeneric tear-down-scene (scene)

--- a/src/generic.lisp
+++ b/src/generic.lisp
@@ -134,3 +134,9 @@ Force a reload & free old memory when FORCE-RELOAD is T."))
 
 (defgeneric image-draw (image obj)
   (:documentation "Draw an object OBJ onto the the rl-image IMAGE."))
+
+(defgeneric setup-scene (scene)
+  (:documentation "Load a SCENE's assets and initialize its objects."))
+
+(defgeneric tear-down-scene (scene)
+  (:documentation "Free a SCENE's assets and objects."))

--- a/src/scene.lisp
+++ b/src/scene.lisp
@@ -106,7 +106,7 @@
                (setf (gethash (car object) (objects ,sym)) (cadr object)))
              ,sym)))))
 
-(defmacro make-scene ((&key (active t) (free :now) (gpu t)) assets objects)
+(defmacro make-scene (assets objects &key (active t) (free :now) (gpu t))
   (let ((scene (gensym))
         (objects (if gpu
                      (loop for (binding val) in objects

--- a/src/scene.lisp
+++ b/src/scene.lisp
@@ -133,11 +133,11 @@ This is useful for objects like TEXTURES which require an OpenGL context to be l
                                        `(,obj (gethash ',obj (objects ,scene)))))
      ,@body))
 
-
 (defmacro with-scenes (scenes &body body)
   "Execute BODY after loading & initializing SCENES, tearing them down afterwards.
 
 Note: additional scenes can be loaded/freed within the loop using {SET-UP,TEAR-DOWN}-SCENE."
+  (unless (listp scenes) (setf scenes `(list ,scenes)))
   `(progn
      (mapcar #'set-up-scene ,scenes)
      ,@body

--- a/src/scene.lisp
+++ b/src/scene.lisp
@@ -156,14 +156,13 @@ This is useful for objects like TEXTURES which require an OpenGL context to be l
         (t (error ":FREE must be :NOW, :LATER, or :NEVER")))))
 
 (defvar *scene* nil
-  "Holds the current scene in a game loop.")
+  "Holds the current scene in a particular game loop.
+Note that *SCENE*, as a special variable, is given a dynamic binding for every game loop.")
 
-;; TODO Perhaps make this generic so users can define :before, :after, :around methods?
-(defun switch-scene (new-scene)
-  "Switch to NEW-SCENE, loading it & unloading the previous scene."
-  (unless (eq new-scene *scene*)
+(defmethod switch-scene ((scene game-scene))
+  (unless (eq scene *scene*)
     (when *scene* (tear-down-scene *scene*))
-    (setf *scene* new-scene)
+    (setf *scene* scene)
     (set-up-scene *scene*)))
 
 (defmethod set-up-scene ((scene game-scene))

--- a/src/scene.lisp
+++ b/src/scene.lisp
@@ -163,7 +163,6 @@ Note that *SCENE*, as a special variable, is given a dynamic binding for every g
     (set-up-scene *scene*)))
 
 (defmethod set-up-scene ((scene game-scene))
-  "Load a SCENE's assets and initialize its objects."
   (load-scene-all scene)
   (maphash (lambda (binding val)
              "Yield the futures in the objects hash table in place."
@@ -174,7 +173,6 @@ Note that *SCENE*, as a special variable, is given a dynamic binding for every g
 (defmethod set-up-scene ((scene null)) ())
 
 (defmethod tear-down-scene ((scene game-scene))
-  "Unload a SCENE according to its %FREE slot."
   (case (free scene)
     (:now (progn
             (unload-scene-all scene)

--- a/src/scene.lisp
+++ b/src/scene.lisp
@@ -151,7 +151,8 @@
         (:never nil)
         (t (error ":FREE must be :NOW, :LATER, or :NEVER")))))
 
-(defparameter *scene* nil) ; the current scene in the game loop
+(defvar *scene* nil
+  "Holds the current scene in a game loop.")
 
 ;; TODO Perhaps make this generic so users can define :before, :after, :around methods?
 (defun switch-scene (new-scene)

--- a/src/scene.lisp
+++ b/src/scene.lisp
@@ -159,9 +159,9 @@
   (unless (eq new-scene *scene*)
     (when *scene* (tear-down-scene *scene*))
     (setf *scene* new-scene)
-    (setup-scene *scene*)))
+    (set-up-scene *scene*)))
 
-(defmethod setup-scene ((scene game-scene))
+(defmethod set-up-scene ((scene game-scene))
   "Load a SCENE's assets and initialize its objects."
   (load-scene-all scene)
   (maphash (lambda (binding val)

--- a/src/scene.lisp
+++ b/src/scene.lisp
@@ -106,9 +106,13 @@
                (setf (gethash (car object) (objects ,sym)) (cadr object)))
              ,sym)))))
 
-(defmacro make-scene (assets objects &key (active t) (free :now) (gpu t))
+(defmacro make-scene (assets objects &key (active t) (free :now) (defer-init t))
+  "Make a GAME-SCENE.
+
+DEFER-INIT will defer initialization of the scene's OBJECTS until later (usually in DO-GAME-LOOP).
+This is useful for objects like TEXTURES which require an OpenGL context to be loaded into the GPU."
   (let ((scene (gensym))
-        (objects (if gpu
+        (objects (if defer-init
                      (loop for (binding val) in objects
                            collect `(,binding (eager-future2:pcall (lambda () ,val) :lazy)))
                      objects)))

--- a/src/scene.lisp
+++ b/src/scene.lisp
@@ -170,6 +170,8 @@
                (setf (gethash binding (objects scene)) (eager-future2:yield val))))
            (objects scene)))
 
+(defmethod set-up-scene ((scene null)) ())
+
 (defmethod tear-down-scene ((scene game-scene))
   "Unload a SCENE according to its %FREE slot."
   (case (free scene)
@@ -179,3 +181,5 @@
     (:later (unload-scene-all-later scene))
     (:never nil)
     (t (error "%FREE must be :NOW, :LATER, or :NEVER"))))
+
+(defmethod tear-down-scene ((scene null)) ())

--- a/src/scene.lisp
+++ b/src/scene.lisp
@@ -8,7 +8,13 @@
    (%game-assets :initarg :assets
                  :type hash-table
                  :initform (make-hash-table :test #'equalp)
-                 :accessor assets)))
+                 :accessor assets)
+   (%active :initarg :active
+            :type boolean
+            :accessor active)
+   (%free :initarg :free
+          :type keyword
+          :accessor free)))
 
 (defun load-scene (scene &rest names)
   (dolist (asset names)
@@ -100,11 +106,13 @@
                (setf (gethash (car object) (objects ,sym)) (cadr object)))
              ,sym)))))
 
-(defmacro make-scene (assets objects)
+(defmacro make-scene ((&key (active t) (free :now) (gpu t)) assets objects)
   (let ((scene (gensym))
-        (objects (loop for (binding val) in objects
-                       collect `(,binding (eager-future2:pcall (lambda () ,val) :lazy)))))
-    `(let ((,scene (make-instance 'game-scene)))
+        (objects (if gpu
+                     (loop for (binding val) in objects
+                           collect `(,binding (eager-future2:pcall (lambda () ,val) :lazy)))
+                     objects)))
+    `(let ((,scene (make-instance 'game-scene :active ,active :free ,free)))
        (let* (,@assets ,@objects)
          (declare (ignorable ,@(mapcar #'car (append assets objects))))
          (progn
@@ -125,6 +133,7 @@
      ,@body))
 
 
+;; TODO Replaced by do-game-loop enhancements
 (defmacro with-scene (scene (&key (free :now)) &body body)
   `(progn
      (load-scene-all ,scene)
@@ -141,3 +150,32 @@
         (:later `(unload-scene-all-later ,scene))
         (:never nil)
         (t (error ":FREE must be :NOW, :LATER, or :NEVER")))))
+
+(defparameter *scene* nil) ; the current scene in the game loop
+
+;; TODO Perhaps make this generic so users can define :before, :after, :around methods?
+(defun switch-scene (new-scene)
+  "Switch to NEW-SCENE, loading it & unloading the previous scene."
+  (unless (eq new-scene *scene*)
+    (when *scene* (tear-down-scene *scene*))
+    (setf *scene* new-scene)
+    (setup-scene *scene*)))
+
+(defmethod setup-scene ((scene game-scene))
+  "Load a SCENE's assets and initialize its objects."
+  (load-scene-all scene)
+  (maphash (lambda (binding val)
+             "Yield the futures in the objects hash table in place."
+             (when (typep val 'eager-future2:future)
+               (setf (gethash binding (objects scene)) (eager-future2:yield val))))
+           (objects scene)))
+
+(defmethod tear-down-scene ((scene game-scene))
+  "Unload a SCENE according to its %FREE slot."
+  (case (free scene)
+    (:now (progn
+            (unload-scene-all scene)
+            (collect-garbage)))
+    (:later (unload-scene-all-later scene))
+    (:never nil)
+    (t (error "%FREE must be :NOW, :LATER, or :NEVER"))))

--- a/src/scene.lisp
+++ b/src/scene.lisp
@@ -9,9 +9,6 @@
                  :type hash-table
                  :initform (make-hash-table :test #'equalp)
                  :accessor assets)
-   (%active :initarg :active
-            :type boolean
-            :accessor active)
    (%free :initarg :free
           :type keyword
           :accessor free)))
@@ -106,7 +103,7 @@
                (setf (gethash (car object) (objects ,sym)) (cadr object)))
              ,sym)))))
 
-(defmacro make-scene (assets objects &key (active t) (free :now) (defer-init t))
+(defmacro make-scene (assets objects &key (free :now) (defer-init t))
   "Make a GAME-SCENE.
 
 DEFER-INIT will defer initialization of the scene's OBJECTS until later (usually in DO-GAME-LOOP).
@@ -116,7 +113,7 @@ This is useful for objects like TEXTURES which require an OpenGL context to be l
                      (loop for (binding val) in objects
                            collect `(,binding (eager-future2:pcall (lambda () ,val) :lazy)))
                      objects)))
-    `(let ((,scene (make-instance 'game-scene :active ,active :free ,free)))
+    `(let ((,scene (make-instance 'game-scene :free ,free)))
        (let* (,@assets ,@objects)
          (declare (ignorable ,@(mapcar #'car (append assets objects))))
          (progn


### PR DESCRIPTION
An attempt at addressing https://github.com/defun-games/claylib/issues/17

We export `game-scene` and `switch-scene`, which uses a new special variable `*scene*` to track the current scene. Simply `setf`ing `*scene*` and doing the loading/unloading at the beginning of a game loop iteration didn't seem like the best way to switch scenes, that's why there is the `switch-scene` convenience function. It allows you to fully switch scenes mid-loop.

As mentioned in 97d107a52549c10b0fc3d89de87ab676aa83c9e5, this is vulnerable to changes in `*SCENE*` whether by nested `do-game-loop` calls or otherwise.

Also this is not addressing potential loads inside a loop. If we don't want to load a scene entirely up-front, then we have to either
1. load it smartly using `set-up-scene` (not exported yet) at some point before we need it (there's potential to do so in a non-blocking way here) so that `switch-scene` does less work, or
2. let it get loaded on demand by `switch-scene`

It is probably safe to push the `tear-down-scene` call in `switch-scene` to another thread unless the `scene`'s `%free` is `:now` and it really must be done now.

Let me know what you're thinking @shelvick. I changed core example 2 to use this new method so you can check that out.