### PR TITLE
Implement scene parameters

### DIFF
--- a/examples/models/billboard.lisp
+++ b/examples/models/billboard.lisp
@@ -9,26 +9,31 @@
                              "examples/models/resources/billboard.png"))))
 
 (defparameter *scene*
-  (make-scene ((bill-ass (car *assets*)))
-              ((grid (make-grid 10 1))
-               (bill (make-billboard bill-ass
-                                     *cam*
-                                     0 2 0
-                                     4 4
-                                     (make-rectangle 0 0
-                                                     (width bill-ass) (height bill-ass)
-                                                     +white+))))))
+  (make-scene-pro (:assets
+                   ((bill-ass (car *assets*)))
+                   :parameters
+                   ((cam (make-camera-3d 5 4 5
+                                         0 2 0
+                                         0 1 0
+                                         :mode +camera-orbital+)))
+                   :objects
+                   ((grid (make-grid 10 1))
+                    (bill (progn (print (claylib::c-struct cam))
+                                 (make-billboard bill-ass
+                                          cam
+                                          0 2 0
+                                          4 4
+                                          (make-simple-rec 0 0
+                                                           (width bill-ass) (height bill-ass)))))))))
 
 (defun main ()
   (with-window (:title "raylib [models] example - drawing billboards")
-    (let ((*cam* (make-camera-3d 5 4 5
-                                 0 2 0
-                                 0 1 0
-                                 :mode +camera-orbital+)))
-      (declare (special *cam*))
-      (with-scenes *scene*
+    (with-scenes *scene*
+      (with-scene-params (cam) *scene*
+        (print (claylib::c-struct cam))
         (do-game-loop (:livesupport t)
-          (update-camera *cam*)
+          (update-camera cam)
           (with-drawing ()
-            (with-3d-mode *cam* (draw-scene-all *scene*))
+            (with-3d-mode cam
+              (draw-scene-all *scene*))
             (draw-fps 10 10)))))))

--- a/examples/models/billboard.lisp
+++ b/examples/models/billboard.lisp
@@ -18,19 +18,17 @@
                                          :mode +camera-orbital+)))
                    :objects
                    ((grid (make-grid 10 1))
-                    (bill (progn (print (claylib::c-struct cam))
-                                 (make-billboard bill-ass
+                    (bill (make-billboard bill-ass
                                           cam
                                           0 2 0
                                           4 4
                                           (make-simple-rec 0 0
-                                                           (width bill-ass) (height bill-ass)))))))))
+                                                           (width bill-ass) (height bill-ass))))))))
 
 (defun main ()
   (with-window (:title "raylib [models] example - drawing billboards")
     (with-scenes *scene*
       (with-scene-params (cam) *scene*
-        (print (claylib::c-struct cam))
         (do-game-loop (:livesupport t)
           (update-camera cam)
           (with-drawing ()

--- a/package.lisp
+++ b/package.lisp
@@ -95,20 +95,20 @@
 
    ;; Misc. convenience wrappers
    :with-window :do-game-loop :with-drawing :is-key-pressed-p :is-gesture-detected-p :is-key-down-p
-   :with-scene-objects :is-mouse-button-pressed-p :get-key-pressed :get-char-pressed
-   :is-mouse-button-down-p :make-vector2 :make-vector3 :make-vector4 :make-camera-3d
-   :make-camera-3d-from-vecs :make-camera-2d :make-camera-2d-from-vecs :make-color :make-rectangle
-   :make-rectangle-from-vecs :make-circle :make-grid :make-cube :make-cube-from-vecs :make-text
-   :make-line-2d :with-2d-mode :with-3d-mode :make-plane :make-ray :make-ray-collision :with-texture-mode
-   :with-scissor-mode :make-zero-matrix :is-window-state-p :make-triangle :make-triangle-from-vecs
-   :make-texture :make-texture-from-rec :make-empty-texture :make-texture-asset :get-gesture-detected
+   :is-mouse-button-pressed-p :get-key-pressed :get-char-pressed :is-mouse-button-down-p
+   :make-vector2 :make-vector3 :make-vector4 :make-camera-3d :make-camera-3d-from-vecs
+   :make-camera-2d :make-camera-2d-from-vecs :make-color :make-rectangle :make-rectangle-from-vecs
+   :make-circle :make-grid :make-cube :make-cube-from-vecs :make-text :make-line-2d :with-2d-mode
+   :with-3d-mode :make-plane :make-ray :make-ray-collision :with-texture-mode :with-scissor-mode
+   :make-zero-matrix :is-window-state-p :make-triangle :make-triangle-from-vecs :make-texture
+   :make-texture-from-rec :make-empty-texture :make-texture-asset :get-gesture-detected
    :is-mouse-button-released-p :make-polygon :make-font :make-image-asset :make-pixel :make-image
    :make-simple-rec :make-billboard :make-font-asset
 
    ;; Scenes
-   :draw-scene-all :scene-object :load-scene-all :unload-scene-all :draw-scene :draw-scene-except
-   :make-scene :objects :draw-scene-regex :with-scenes :set-up-scene :tear-down-scene :draw-objects
-   :make-scene-pro :parameters :assets
+   :draw-scene-all :scene-object :with-scene-objects :load-scene-all :unload-scene-all :draw-scene
+   :draw-scene-except :make-scene :objects :draw-scene-regex :with-scenes :set-up-scene
+   :tear-down-scene :draw-objects :make-scene-pro :parameters :assets :scene-param :with-scene-params
 
    ;; Generic functions/methods
    :x :y :z :color :target :rot :zoom :x1 :y1 :x2 :y2 :width :height :len :offset :pos :draw-object

--- a/package.lisp
+++ b/package.lisp
@@ -108,6 +108,7 @@
    ;; Scenes
    :draw-scene-all :scene-object :load-scene-all :unload-scene-all :draw-scene :draw-scene-except
    :make-scene :objects :draw-scene-regex :with-scenes :set-up-scene :tear-down-scene :draw-objects
+   :make-scene-pro :parameters :assets
 
    ;; Generic functions/methods
    :x :y :z :color :target :rot :zoom :x1 :y1 :x2 :y2 :width :height :len :offset :pos :draw-object

--- a/src/billboard.lisp
+++ b/src/billboard.lisp
@@ -47,7 +47,9 @@ camera).")
   (apply #'make-instance 'billboard
          :allow-other-keys t
          :asset texture-asset
-         :camera camera
+         :camera (if (typep camera 'eager-future2:future)
+                     (eager-future2:yield camera)
+                     camera)
          :pos (make-vector3 x y z)
          :size (make-vector2 x-scale y-scale)
          :source source

--- a/src/scene.lisp
+++ b/src/scene.lisp
@@ -128,10 +128,10 @@ an OpenGL context before being loaded into the GPU."
     `(let ((,scene (make-instance 'game-scene :free ,free)))
        (let* (,@assets ,@objects)
          (declare (ignorable ,@(mapcar #'car (append assets objects))))
-         ,@(loop for (binding val) in assets
-                 collect `(setf (gethash ',binding (assets ,scene)) ,val))
-         ,@(loop for (binding val) in objects
-                 collect `(setf (gethash ',binding (objects ,scene)) ,val)))
+         ,@(loop for (binding _) in assets
+                 collect `(setf (gethash ',binding (assets ,scene)) ,binding))
+         ,@(loop for (binding _) in objects
+                 collect `(setf (gethash ',binding (objects ,scene)) ,binding)))
        ,scene)))
 
 (defmacro make-scene-pro (groups &key (free :now) (defer-init t))

--- a/src/scene.lisp
+++ b/src/scene.lisp
@@ -183,6 +183,16 @@ assets will be freed automatically. The objects also have their initialization d
                                        `(,obj (gethash ',obj (objects ,scene)))))
      ,@body))
 
+(defun scene-param (scene parameter)
+  (gethash parameter (parameters scene)))
+
+(defmacro with-scene-params (parameters scene &body body)
+  `(symbol-macrolet ,(loop for param in parameters
+                           collect (if (listp param)
+                                       `(,(car param) (gethash ,(cadr param) (parameters ,scene)))
+                                       `(,param (scene-param ,scene ',param))))
+     ,@body))
+
 (defmacro with-scenes (scenes &body body)
   "Execute BODY after loading & initializing SCENES, tearing them down afterwards.
 


### PR DESCRIPTION
Addresses: #40 

Things to note:
1. I have yet to make this code not ugly. It's at a working state as of b5d699ae5778d510b647645406a9d56785e9d07b, so I wanted to open it up to review (try to avert your eyes when you get close to `make-scene-pro` though).
2. This also fixes an issue with re-computing identical forms in `make-scene`/`make-scene-pro`, as mentioned in the commit message of 756f318871d1445900b4f0bfd7162cdccc5a4cfa
3. I took an approach with billboards as part of a fix to (2.) which changes `make-billboard` to yield its `camera` argument when it's a future. This is totally fine but it means that whenever we have a case like billboards where the object could refer to a future, we have to add the "check and yield" to its `make-*` function.

The main thing I want to know is whether this approach is how you'd like to continue, now that you can see it in action.