### PR TITLE
1st gen extract-model-data & complete(?) model implementation notes

### DIFF
--- a/src/game-asset.lisp
+++ b/src/game-asset.lisp
@@ -92,13 +92,34 @@
 (defreader bones model-asset bones asset)
 (defreader bind-pose model-asset bind-pose asset)
 
+(defwriter mesh-count model-asset mesh-count asset)
+(defwriter material-count model-asset material-count asset)
+(defwriter mesh-material model-asset mesh-material asset)
+(defwriter bone-count model-asset bone-count asset)
+(defwriter transform model-asset transform asset)
+(defwriter meshes model-asset meshes asset)
+(defwriter materials model-asset materials asset)
+(defwriter bones model-asset bones asset)
+(defwriter bind-pose model-asset bind-pose asset)
+
 (defmethod load-asset ((asset model-asset) &key force-reload)
+  ;; TODO: use this below
+  ;; (flet ((load-it (rl-model path)
+  ;;          "Extract the model data from the file at PATH, then plug it into RL-MODEL's fields."
+  ;;          (let ((model-data (extract-model-data path)))
+  ;;            (setf (mesh-count rl-model) (getf model-data :mesh-count)
+  ;;                  ...))))
+  ;;   ...)
   (cond
     ((null (asset asset))
      (let ((model (make-instance 'rl-model)))
+       ;; TODO: replace following sexp with:
+       ;; (load-it model (path asset))
        (claylib/ll:load-model (c-struct model) (namestring (path asset)))
        (setf (asset asset) model)))
     (force-reload
+     ;; TODO: replace following sexp with:
+     ;; (load-it (c-asset asset) (path asset))
      (claylib/ll:load-model (c-asset asset) (namestring (path asset)))))
   asset)
 


### PR DESCRIPTION
TODO: implement the needed "c-copy" functions for model data and check other TODOs on how to transition to their use.

NOTE 1: The annotations do not specify how to deal with model animations. Animations are separate from models in raylib, but it should be possible to unite raylib models and raylib model animations in claylib models. It's a little involved but, vaguely, we'd include a call to claylib/ll:load-model-animations (and more "c-copy" functions) in extract-model-data, add an %animations slot to claylib models & model-assets, def the appropriate accessors, use said accessors to set animation related fields in make-model, write a appropriate update-model-animation pass-through, ???, profit. Or we could settle for separately loaded animations like raylib.

NOTE 2: When freeing a claylib model we need to free only the parts which don't come from a model-asset. This may be tricky as we have an rl-model backing with some fields (for example transforms) we want to free and others (meshes etc.) we don't. Same goes for the animation data.