### PR TITLE
Mostly done: C arrays -> Lisp sequences

### DIFF
--- a/claylib.asd
+++ b/claylib.asd
@@ -42,7 +42,7 @@
   :version "0.0.1"
   :serial t
   :depends-on (#:claylib/ll #:cl-plus-c #:trivial-garbage #:livesupport #:closer-mop
-               #:eager-future2)
+               #:eager-future2 #:trivial-extensible-sequences)
   :components ((:file "package")
                (:module "src"
                 :components ((:file "generic")

--- a/package.lisp
+++ b/package.lisp
@@ -1,6 +1,7 @@
 ;;;; package.lisp
 (defpackage #:claylib
   (:use #:cl #:plus-c #:claylib/ll)
+  (:local-nicknames (#:sequences #:org.shirakumo.trivial-extensible-sequences))
   (:shadow
 
    ;;; Shadowed symbols

--- a/src/anim.lisp
+++ b/src/anim.lisp
@@ -102,7 +102,7 @@ Warning: this can refer to bogus C data if BONE-COUNT does not match the real C 
 (defmethod sequences:length ((sequence rl-bones))
   (length (cl-array sequence)))
 
-(defmethod sequences:elt ((sequence rl-meshes) index)
+(defmethod sequences:elt ((sequence rl-bones) index)
   (elt (cl-array sequence) index))
 
 (defmethod (setf sequences:elt) (value (sequence rl-bones) index)

--- a/src/game-asset.lisp
+++ b/src/game-asset.lisp
@@ -103,26 +103,13 @@
 (defwriter bind-pose model-asset bind-pose asset)
 
 (defmethod load-asset ((asset model-asset) &key force-reload)
-  (flet ((load-it (rl-model path)
-           "Extract the model data from the file at PATH, then plug it into RL-MODEL's fields."
-           (let ((model-data (extract-model-data path)))
-             (set-model (c-struct rl-model)
-                        (getf model-data :transform)
-                        (getf model-data :mesh-count)
-                        (getf model-data :material-count)
-                        (getf model-data :meshes)
-                        (getf model-data :materials)
-                        (getf model-data :mesh-material)
-                        (getf model-data :bone-count)
-                        (getf model-data :bones)
-                        (getf model-data :bind-pose)))))
-    (cond
-      ((null (asset asset))
-       (let ((model (make-instance 'rl-model)))
-         (load-it model (path asset))
-         (setf (asset asset) model)))
-      (force-reload
-       (load-it (asset asset) (path asset)))))
+  (cond
+    ((null (asset asset))
+     (let ((model (make-instance 'rl-model)))
+       (claylib/ll:load-model (c-struct model) (namestring (path asset)))
+       (setf (asset asset) model)))
+    (force-reload
+     (claylib/ll:load-model (c-asset asset) (namestring (path asset)))))
   asset)
 
 (defun make-model-asset (path &key (load-now nil))

--- a/src/game-asset.lisp
+++ b/src/game-asset.lisp
@@ -120,12 +120,9 @@
       ((null (asset asset))
        (let ((model (make-instance 'rl-model)))
          (load-it model (path asset))
-         ;(claylib/ll:load-model (c-struct model) (namestring (path asset)))
          (setf (asset asset) model)))
       (force-reload
-       (load-it (c-asset asset) (path asset))
-       ;(claylib/ll:load-model (c-asset asset) (namestring (path asset)))
-       )))
+       (load-it (asset asset) (path asset)))))
   asset)
 
 (defun make-model-asset (path &key (load-now nil))

--- a/src/mesh.lisp
+++ b/src/mesh.lisp
@@ -100,12 +100,12 @@
 (defmethod sequences:elt ((sequence rl-meshes) index)
   (elt (cl-array sequence) index))
 
-(defmethod (setf sequences:elt) (value (sequence rl-meshes) index) ;; (n rl-meshes rl-mesh)
+(defmethod (setf sequences:elt) (value (sequence rl-meshes) index)
   "Set the element at INDEX of the rl-meshes SEQUENCE such that it contains a copy of the C data in
 VALUE (an rl-mesh).
 
-Since rl-meshes deals with a C array (contiguous memory), we cannot simply change the location of
-the data by changing the pointer, we must memcpy it in.
+Since rl-meshes deals with a C array (contiguous memory), we cannot simply change the data of any
+particular element by changing the pointer, we must memcpy it in.
 
 Example:
 (set-meshes-element n rl-meshes rl-mesh)

--- a/src/mesh.lisp
+++ b/src/mesh.lisp
@@ -121,7 +121,6 @@ Example:
 \"To set the nth element of rl-meshes, set the nth element of its %cl-array slot & overwrite the
 nth element of the underlying c-struct.\""
   (check-type value rl-mesh)
-  ;; TODO: should this be a deep copy for the pointer fields in a Mesh?
   (cffi:foreign-funcall "memcpy"
                         :pointer (autowrap:ptr (c-struct (elt sequence index)))
                         :pointer (autowrap:ptr (c-struct value))

--- a/src/mesh.lisp
+++ b/src/mesh.lisp
@@ -52,14 +52,13 @@
 
 
 
-;; TODO when we make-model, set %meshes to an rl-meshes object holding the model.meshes pointer
 (defclass rl-meshes (sequence)
   ((%pointer :initarg :pointer
              :initform (error "Must give initial :POINTER argument.")
              :accessor pointer
              :documentation "The pointer a raylib Model keeps in their meshes field.")
    ;; Note: On init, we can set to the mesh-count of the model. But we must update mesh-count
-   ;; manually when the # of elements changes
+   ;; manually whenever the # of elements changes
    (%mesh-count :initarg :mesh-count
                 :initform (error "Must give initial :MESH-COUNT argument.")
                 :reader mesh-count
@@ -72,8 +71,15 @@
   (check-type index integer)
   (when (>= index (mesh-count sequence))
     (error "Index out of bounds."))
-  (cffi:mem-aref (pointer sequence) :mesh index))
+  (autowrap:c-aref sequence index 'mesh))
 
 (defmethod (setf sequences:elt) (value (sequence rl-meshes) index)
   (check-type index integer)
   ())
+
+(defmethod sequences:adjust-sequence ((sequence rl-meshes) length
+                                      &key initial-contents initial-element)
+  )
+
+(defmethod sequences:make-sequence-like ((sequence rl-meshes) length
+                                         &key initial-contents initial-element))

--- a/src/mesh.lisp
+++ b/src/mesh.lisp
@@ -72,7 +72,7 @@
 (defconstant +foreign-mesh-size+ (cffi:foreign-type-size '(:struct mesh)))
 
 (defclass rl-meshes (sequences:sequence)
-  ((%cl-array :type simple-vector ;; TODO define array type to ensure elements are rl-mesh objects
+  ((%cl-array :type (array rl-mesh 1)
               :accessor cl-array
               :documentation "A Lisp array of RL-MESH objects tracking the C Mesh array underneath.")))
 
@@ -118,6 +118,7 @@ nth element of the underlying c-struct.\""
                         :int +foreign-mesh-size+
                         :void))
 
+;; TODO: Necessary? Can we safely leave this unimplemented?
 ;; (defmethod sequences:adjust-sequence ((sequence rl-meshes) length
 ;;                                       &key initial-contents initial-element)
 ;; ;; Cannot meaningfully change length
@@ -128,7 +129,13 @@ nth element of the underlying c-struct.\""
 ;;      (error "Cannot give both INITIAL-CONTENTS and INITIAL-ELEMENT"))
 
 ;;     (initial-contents
-;;      )
+;;      (loop for rl-mesh in initial-contents
+;;            do ; copy each mesh in
+;;            ))
 
 ;;     (initial-element
 ;;      )))
+
+;; TODO: Necessary? Can we safely leave this unimplemented?
+;; (defmethod sequences:make-sequence-like ((sequence rl-meshes) length
+;;                                          &key initial-contents initial-ellement))

--- a/src/mesh.lisp
+++ b/src/mesh.lisp
@@ -55,8 +55,8 @@
 ;; TODO: inherit from sequence, define sequence methods to ease access
 (defclass rl-meshes ()
   ((%cl-array :type simple-vector ;; TODO define array type to ensure elements are rl-mesh objects
-           :accessor cl-array
-           :documentation "A Lisp array of RL-MESH objects tracking the C Mesh array underneath.")))
+              :accessor cl-array
+              :documentation "A Lisp array of RL-MESH objects tracking the C Mesh array underneath.")))
 
 (defmethod initialize-instance :after ((meshes rl-meshes) &key c-struct mesh-count)
   ;; Note: C-STRUCT is the mesh wrapper at the start of the array.
@@ -77,24 +77,22 @@
                       :initial-contents contents))))
 
 ;; TODO: Does autowrap give me something like this already? I need to know the size for memcpy later
-;; but this method is not guaranteed to work as many of these values are pointers which are not
-;; guaranteed to have the same size as ints.
 (cffi:defcstruct mesh
   (vertex-count :int)
   (triangle-count :int)
-  (vertices :int)
-  (tex-coords :int)
-  (tex-coords2 :int)
-  (normals :int)
-  (tangents :int)
-  (colors :int)
-  (indices :int)
-  (anim-vertices :int)
-  (anim-normals :int)
-  (bone-ids :int)
-  (bone-weights :int)
+  (vertices :pointer)
+  (tex-coords :pointer)
+  (tex-coords2 :pointer)
+  (normals :pointer)
+  (tangents :pointer)
+  (colors :pointer)
+  (indices :pointer)
+  (anim-vertices :pointer)
+  (anim-normals :pointer)
+  (bone-ids :pointer)
+  (bone-weights :pointer)
   (vao-id :uint)
-  (vbo-id :int))
+  (vbo-id :pointer))
 (defconstant +foreign-mesh-size+ (cffi:foreign-type-size '(:struct mesh)))
 
 ;; TODO:

--- a/src/mesh.lisp
+++ b/src/mesh.lisp
@@ -98,9 +98,6 @@
   (length (cl-array sequence)))
 
 (defmethod sequences:elt ((sequence rl-meshes) index)
-  (check-type index integer)
-  (unless (<= 0 index (length sequence))
-    (error "Index out of bounds."))
   (elt (cl-array sequence) index))
 
 (defmethod (setf sequences:elt) (value (sequence rl-meshes) index) ;; (n rl-meshes rl-mesh)

--- a/src/mesh.lisp
+++ b/src/mesh.lisp
@@ -82,11 +82,12 @@
   (vbo-id :pointer))
 (defconstant +foreign-mesh-size+ (cffi:foreign-type-size '(:struct mesh)))
 
-(defclass rl-meshes (sequences:sequence)
-  ((%cl-array :type (array rl-mesh 1)
-              :initarg :cl-array
-              :reader cl-array
-              :documentation "A Lisp array of RL-MESH objects tracking the C Mesh array underneath.")))
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (defclass rl-meshes (sequences:sequence)
+    ((%cl-array :type (array rl-mesh 1)
+                :initarg :cl-array
+                :reader cl-array
+                :documentation "An RL-MESH array tracking the C Mesh array underneath."))))
 
 (defun make-meshes-array (c-struct mesh-count)
   "Make an array of rl-mesh objects using MESH-COUNT elements of the Mesh wrapper C-STRUCT.

--- a/src/mesh.lisp
+++ b/src/mesh.lisp
@@ -118,8 +118,10 @@ particular element by changing the pointer, we must memcpy it in.
 Example:
 (set-meshes-element n rl-meshes rl-mesh)
 
-\"To set the nth element of rl-meshes, set the nth element of its %array slot & overwrite the
+\"To set the nth element of rl-meshes, set the nth element of its %cl-array slot & overwrite the
 nth element of the underlying c-struct.\""
+  (check-type value rl-mesh)
+  ;; TODO: should this be a deep copy for the pointer fields in a Mesh?
   (cffi:foreign-funcall "memcpy"
                         :pointer (autowrap:ptr (c-struct (elt sequence index)))
                         :pointer (autowrap:ptr (c-struct value))

--- a/src/mesh.lisp
+++ b/src/mesh.lisp
@@ -49,3 +49,31 @@
 
 (default-free rl-mesh)
 (default-free-c claylib/ll:mesh unload-mesh)
+
+
+
+;; TODO when we make-model, set %meshes to an rl-meshes object holding the model.meshes pointer
+(defclass rl-meshes (sequence)
+  ((%pointer :initarg :pointer
+             :initform (error "Must give initial :POINTER argument.")
+             :accessor pointer
+             :documentation "The pointer a raylib Model keeps in their meshes field.")
+   ;; Note: On init, we can set to the mesh-count of the model. But we must update mesh-count
+   ;; manually when the # of elements changes
+   (%mesh-count :initarg :mesh-count
+                :initform (error "Must give initial :MESH-COUNT argument.")
+                :reader mesh-count
+                :documentation "The number of meshes in this raylib array.")))
+
+(defmethod sequences:length ((sequence rl-meshes))
+  (mesh-count sequence))
+
+(defmethod sequences:elt ((sequence rl-meshes) index)
+  (check-type index integer)
+  (when (>= index (mesh-count sequence))
+    (error "Index out of bounds."))
+  (cffi:mem-aref (pointer sequence) :mesh index))
+
+(defmethod (setf sequences:elt) (value (sequence rl-meshes) index)
+  (check-type index integer)
+  ())

--- a/src/mesh.lisp
+++ b/src/mesh.lisp
@@ -54,9 +54,9 @@
 
 ;; TODO: inherit from sequence, define sequence methods to ease access
 (defclass rl-meshes ()
-  ((%lisp-array :type simple-vector ;; TODO define array type to ensure elements are rl-mesh objects
-                :accessor lisp-array
-                :documentation "A Lisp array of RL-MESH objects that tracks the C Mesh array
+  ((%array :type simple-vector ;; TODO define array type to ensure elements are rl-mesh objects
+           :accessor array
+           :documentation "A Lisp array of RL-MESH objects that tracks the C Mesh array
 (i.e. %C-STRUCT) underneath.")
    ;; TODO: get rid of %c-struct, it is unnecessary after initializing the array
    (%c-struct :initarg :c-struct
@@ -78,7 +78,7 @@
                         do (setf (slot-value mesh '%c-struct)
                                  (autowrap:c-aref c-struct i 'claylib/wrap:mesh))
                         collect mesh)))
-    (setf (lisp-array meshes)
+    (setf (array meshes)
           (make-array mesh-count
                       :element-type 'rl-mesh
                       :initial-contents contents))))
@@ -115,7 +115,7 @@
 Example:
 (set-meshes-element n rl-meshes rl-mesh)
 
-\"To set the nth element of rl-meshes, set the nth element of its %lisp-array slot & overwrite the
+\"To set the nth element of rl-meshes, set the nth element of its %array slot & overwrite the
 nth element of the underlying c-struct.\""
   ;; When memcpying, this setf is unnecessary. The lisp array will contain the new rl-mesh object
   ;; but the C array will already have that data copied into it.
@@ -125,10 +125,10 @@ nth element of the underlying c-struct.\""
   ;; C array). Then to set an rl-mesh in an rl-meshes, it's a matter of memcpying the new data to
   ;; the known location
   ;;
-  ;; (setf (elt (lisp-array rl-meshes) n) rl-mesh)
+  ;; (setf (elt (array rl-meshes) n) rl-mesh)
   (cffi:foreign-funcall "memcpy"
                         ;; :pointer (autowrap:c-aptr (c-struct rl-meshes) n 'claylib/wrap:mesh)
-                        :pointer (autowrap:ptr (c-struct (elt (lisp-array rl-meshes) n)))
+                        :pointer (autowrap:ptr (c-struct (elt (array rl-meshes) n)))
                         :pointer (autowrap:ptr (c-struct rl-mesh))
                         :int +foreign-mesh-size+
                         :void))

--- a/src/model.lisp
+++ b/src/model.lisp
@@ -12,7 +12,7 @@
                  ;; :type rl-materials  ; TODO: make rl-materials sequence type
                  :reader materials)
      (%bones :initarg :bones
-             ;; :type rl-bones  ; TODO: make rl-bones sequence type
+             :type rl-bones
              :reader bones)
      (%bind-pose :initarg :bind-pose
                  :type rl-transform ; pointer
@@ -133,10 +133,10 @@ Models are backed by RL-MODELs which draw reusable data from the given MODEL-ASS
                       :pos (make-vector3 x y z)
                       args))
         (rl-asset model-asset)
-        (c-meshes (autowrap:c-aref (model.meshes (c-asset model-asset)) 0 'claylib/wrap:mesh)))
+        (c-meshes (autowrap:c-aref (model.meshes (c-asset model-asset)) 0 'claylib/wrap:mesh))
+        (c-bones (autowrap:c-aref (model.bones (c-asset model-asset)) 0 'claylib/wrap:bone-info)))
     (set-slot :transform model (or transform (transform rl-asset))) ; TODO (make-zero-matrix) here?
     (set-slot :materials model (or materials (materials rl-asset)))
-    (set-slot :bones model (or bones (bones rl-asset)))
     (set-slot :bind-pose model (or bind-pose (bind-pose rl-asset)))
     (setf (mesh-count model) (or mesh-count (mesh-count rl-asset))
           (meshes model) (or meshes
@@ -145,7 +145,11 @@ Models are backed by RL-MODELs which draw reusable data from the given MODEL-ASS
                                                                          (mesh-count model))))
           (material-count model) (or material-count (material-count rl-asset))
           (mesh-material model) (or mesh-material (mesh-material rl-asset))
-          (bone-count model) (or bone-count (bone-count rl-asset)))
+          (bone-count model) (or bone-count (bone-count rl-asset))
+          (bones model) (or bones
+                            (make-instance 'rl-bones
+                                           :cl-array (make-bones-array c-bones
+                                                                       (bone-count model)))))
     ;; TODO: anims
     model))
 

--- a/src/model.lisp
+++ b/src/model.lisp
@@ -99,7 +99,9 @@ Models are backed by RL-MODELs which draw reusable data from the given MODEL-ASS
           ;; TODO make rl-materials
           ;; TODO make rl-bones
           ;; TODO make rl-bind-pose
-          )
+          (mesh-count model) (mesh-count model-asset)
+          (material-count model) (material-count model-asset)
+          (bone-count (bone-count model-asset)))
     model))
 
 (defmethod free ((obj model))

--- a/src/model.lisp
+++ b/src/model.lisp
@@ -132,7 +132,8 @@ Models are backed by RL-MODELs which draw reusable data from the given MODEL-ASS
                       :asset model-asset
                       :pos (make-vector3 x y z)
                       args))
-        (rl-asset model-asset))
+        (rl-asset model-asset)
+        (c-meshes (autowrap:c-aref (model.meshes (c-asset model-asset)) 0 'claylib/wrap:mesh)))
     (set-slot :transform model (or transform (transform rl-asset))) ; TODO (make-zero-matrix) here?
     (set-slot :materials model (or materials (materials rl-asset)))
     (set-slot :bones model (or bones (bones rl-asset)))
@@ -140,11 +141,8 @@ Models are backed by RL-MODELs which draw reusable data from the given MODEL-ASS
     (setf (mesh-count model) (or mesh-count (mesh-count rl-asset))
           (meshes model) (or meshes
                              (make-instance 'rl-meshes
-                                            :c-struct (autowrap:c-aref
-                                                       (model.meshes (c-asset rl-asset))
-                                                       0
-                                                       'claylib/wrap:mesh)
-                                            :mesh-count (mesh-count model)))
+                                            :cl-array (make-meshes-array c-meshes
+                                                                         (mesh-count model))))
           (material-count model) (or material-count (material-count rl-asset))
           (mesh-material model) (or mesh-material (mesh-material rl-asset))
           (bone-count model) (or bone-count (bone-count rl-asset)))

--- a/src/model.lisp
+++ b/src/model.lisp
@@ -101,7 +101,7 @@ Models are backed by RL-MODELs which draw reusable data from the given MODEL-ASS
           ;; TODO make rl-bind-pose
           (mesh-count model) (mesh-count model-asset)
           (material-count model) (material-count model-asset)
-          (bone-count (bone-count model-asset)))
+          (bone-count model) (bone-count model-asset))
     model))
 
 (defmethod free ((obj model))

--- a/src/model.lisp
+++ b/src/model.lisp
@@ -9,7 +9,7 @@
               :type rl-meshes
               :accessor meshes)
      (%materials :initarg :materials
-                 ;; :type rl-materials  ; TODO: make rl-materials sequence type
+                 :type rl-materials  ; TODO: make rl-materials sequence type
                  :reader materials)
      (%bones :initarg :bones
              :type rl-bones

--- a/src/model.lisp
+++ b/src/model.lisp
@@ -113,21 +113,3 @@ Models are backed by RL-MODELs which draw reusable data from the given MODEL-ASS
                             (rot-angle obj)
                             (c-struct (scale obj))
                             (c-struct (tint obj))))
-
-(defun extract-model-data (path)
-  "Return a plist of the model data of interest in the file at PATH."
-  (let* ((rl-model (make-instance 'rl-model))
-         (c-model (c-struct rl-model)))
-    (claylib/ll:load-model c-model (namestring path))
-    ;; TODO: make copies of the following fields, need copy functions!
-    (list :transform      (model.transform c-model)
-          :mesh-count     (mesh-count rl-model)
-          :material-count (material-count rl-model)
-          :meshes         (model.meshes c-model)
-          :materials      (model.materials c-model)
-          :mesh-material  (mesh-material rl-model)
-          :bone-count     (bone-count rl-model)
-          :bones          (model.bones c-model)
-          :bind-pose      (model.bind-pose c-model))
-    ;; TODO: free rl-model
-    ))

--- a/src/model.lisp
+++ b/src/model.lisp
@@ -79,8 +79,7 @@ Models are backed by RL-MODELs which draw reusable data from the given MODEL-ASS
   (load-asset model-asset)
   (let ((model (apply #'make-instance 'model
                       :pos (make-vector3 x y z)
-                      args))
-        (base-model (c-asset model-asset)))
+                      args)))
     (set-model (c-struct model)
                (c-struct (make-zero-matrix))  ; fresh transform for each instance
                (mesh-count model-asset)
@@ -92,7 +91,10 @@ Models are backed by RL-MODELs which draw reusable data from the given MODEL-ASS
                (model.bones (c-asset model-asset))
                (model.bind-pose (c-asset model-asset)))
     (setf (meshes model) (make-instance 'rl-meshes
-                                        :pointer (model.meshes (c-asset model-asset))
+                                        :c-struct (autowrap:c-aref
+                                                   (model.meshes (c-asset model-asset))
+                                                   0
+                                                   'claylib/wrap:mesh)
                                         :mesh-count (mesh-count model-asset))
           ;; TODO make rl-materials
           ;; TODO make rl-bones

--- a/src/model.lisp
+++ b/src/model.lisp
@@ -138,12 +138,13 @@ Models are backed by RL-MODELs which draw reusable data from the given MODEL-ASS
     (set-slot :bones model (or bones (bones rl-asset)))
     (set-slot :bind-pose model (or bind-pose (bind-pose rl-asset)))
     (setf (mesh-count model) (or mesh-count (mesh-count rl-asset))
-          (meshes model) (make-instance 'rl-meshes
-                                        :c-struct (autowrap:c-aref
-                                                   (model.meshes (c-asset rl-asset))
-                                                   0
-                                                   'claylib/wrap:mesh)
-                                        :mesh-count (mesh-count model))
+          (meshes model) (or meshes
+                             (make-instance 'rl-meshes
+                                            :c-struct (autowrap:c-aref
+                                                       (model.meshes (c-asset rl-asset))
+                                                       0
+                                                       'claylib/wrap:mesh)
+                                            :mesh-count (mesh-count model)))
           (material-count model) (or material-count (material-count rl-asset))
           (mesh-material model) (or mesh-material (mesh-material rl-asset))
           (bone-count model) (or bone-count (bone-count rl-asset)))

--- a/src/model.lisp
+++ b/src/model.lisp
@@ -6,7 +6,7 @@
                :reader transform)
    (%meshes :initarg :meshes
             :type rl-meshes
-            :reader meshes)
+            :accessor meshes)
    (%materials :initarg :materials
                                         ; TODO: make rl-materials sequence type
                :reader materials)


### PR DESCRIPTION
`rl-materials` is incomplete due to `rl-material-maps` being incomplete.

Notes to self:
- find the maps length (@shelvick said it was statically defined somewhere)
- generalize C array sequence types. `length` and `elt` are shared, specialize `setf` when necessary
- there's probably an obvious way to improve the `make-*-array` functions. At first I tried defining an `initialize-instance :after` method but that seemed dumb when I could be computing what should be in `%cl-array` and then passing it to `make-instance` (hence `make-*-array`)